### PR TITLE
Add function for merging multiple json config documents

### DIFF
--- a/jiant/utils/config.py
+++ b/jiant/utils/config.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 """This module contains utilities for manipulating configs."""
+from typing import List
+
+import json
 import _jsonnet  # type: ignore
 
 
 def json_merge_patch(target_json: str, patch_json: str) -> str:
-    """Merge json objects according to JSON merge patch spec: https://tools.ietf.org/html/rfc7396
+    """Merge json objects according to JSON merge patch spec: https://tools.ietf.org/html/rfc7396.
 
     Takes a target json string, and a patch json string and applies the patch json to the target
     json according to "JSON Merge Patch" (defined by https://tools.ietf.org/html/rfc7396).
@@ -15,6 +18,7 @@ def json_merge_patch(target_json: str, patch_json: str) -> str:
 
     Returns:
         json str after applying the patch json to the target json using "JSON Merge Patch" method.
+
     """
     merged: str = """local target = {target_json};
                      local patch = {patch_json};
@@ -22,3 +26,27 @@ def json_merge_patch(target_json: str, patch_json: str) -> str:
         target_json=target_json, patch_json=patch_json
     )
     return _jsonnet.evaluate_snippet("snippet", merged)
+
+
+def merge_jsons_in_order(jsons: List[str]) -> str:
+    """Applies JSON Merge Patch process to a list of json documents in order.
+
+    Takes a list of json document strings and performs "JSON Merge Patch" (see json_merge_patch).
+    The first element in the list of json docs is treated as the base, subsequent docs (if any)
+    are applied as patches in order from first to last.
+
+    Args:
+        jsons: list of json docs to merge into a composite json document.
+
+    Returns:
+        The composite json document string.
+
+    """
+    base_json = jsons.pop(0)
+    # json.loads is called to check that input strings are valid json.
+    json.loads(base_json)
+    composite_json = base_json
+    for json_str in jsons:
+        json.loads(json_str)
+        composite_json = json_merge_patch(composite_json, json_str)
+    return composite_json

--- a/tests/utils/config/base_config.json
+++ b/tests/utils/config/base_config.json
@@ -1,0 +1,9 @@
+{
+  "run_name": "BERT_BASE",
+  "model": "BERT",
+  "tasks": ["mrpc"],
+  "params": {
+    "lr": 0.0003,
+    "val_interval": 100
+  }
+}

--- a/tests/utils/config/final_config.json
+++ b/tests/utils/config/final_config.json
@@ -1,0 +1,9 @@
+{
+  "run_name": "BERT_BASE",
+  "model": "BERT",
+  "tasks": ["sst", "mrpc"],
+  "params": {
+    "val_interval": 100
+  },
+  "add_on_setting": "added_last"
+}

--- a/tests/utils/config/first_override_config.json
+++ b/tests/utils/config/first_override_config.json
@@ -1,0 +1,8 @@
+{
+  "run_name": "BERT_BASE",
+  "model": "BERT",
+  "tasks": ["sst", "mrpc"],
+  "params": {
+    "lr": null
+  }
+}

--- a/tests/utils/config/second_override_config.json
+++ b/tests/utils/config/second_override_config.json
@@ -1,0 +1,3 @@
+{
+  "add_on_setting": "added_last"
+}

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
+import os
+
 from jiant.utils import config
 
 
@@ -41,3 +43,18 @@ def test_json_merge_patch():
     merged_sorted: str = json.dumps(json.loads(merged), sort_keys=True)
     expected_sorted: str = json.dumps(json.loads(expected), sort_keys=True)
     assert merged_sorted == expected_sorted
+
+
+def test_merging_multiple_json_configs():
+    with open(os.path.join(os.path.dirname(__file__), "config/base_config.json")) as f:
+        base_config = f.read()
+    with open(os.path.join(os.path.dirname(__file__), "./config/first_override_config.json")) as f:
+        override_config_1 = f.read()
+    with open(os.path.join(os.path.dirname(__file__), "./config/second_override_config.json")) as f:
+        override_config_2 = f.read()
+    merged_config = config.merge_jsons_in_order([base_config, override_config_1, override_config_2])
+    with open(os.path.join(os.path.dirname(__file__), "./config/final_config.json")) as f:
+        expected_config = f.read()
+    sorted_merged_config = json.dumps(json.loads(merged_config), sort_keys=True)
+    sorted_expected_config = json.dumps(json.loads(expected_config), sort_keys=True)
+    assert sorted_merged_config == sorted_expected_config


### PR DESCRIPTION
This PR adds a function merge a sequence of JSON config documents in order (with each merge following the JSON Merge Patch standard described [here](https://tools.ietf.org/html/rfc7396).