### PR TITLE
Update docs for new repo org/location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ pip install -r requirements.txt
 Examples to help you get started can be found here [INSERT LINK].
 
 ### Documentation
-Documentation for `jiant` v2.0.dev0 can be found [here](https://pyeres.github.io/jiant/).
+Documentation for `jiant` v2.0.dev0 can be found [here](https://jiant-dev.github.io/jiant/).
 
 ### Issues
-Templates for bug reports and feature requests are provided [here](https://github.com/pyeres/jiant2/issues/new/choose).
+Templates for bug reports and feature requests are provided [here](https://github.com/jiant-dev/jiant/issues/new/choose).
 
 ### Contributing
 The `jiant` project's contributing guidelines can be found [here](CONTRIBUTING.md).
 
 ### License
-`jiant` is released under the [MIT License](https://github.com/pyeres/jiant/blob/master/LICENSE).
+`jiant` is released under the [MIT License](https://github.com/jiant-dev/jiant/blob/master/LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ### Documentation source
 
-This folder contains `jiant`'s documentation source code. The `jiant` project uses [Sphinx](https://www.sphinx-doc.org/en/master/), CircleCI, and GitHub pages to build, deploy, and host these docs. `jiants`'s latest published documentation is hosted [here](https://pyeres.github.io/jiant/).
+This folder contains `jiant`'s documentation source code. The `jiant` project uses [Sphinx](https://www.sphinx-doc.org/en/master/), CircleCI, and GitHub pages to build, deploy, and host these docs. `jiants`'s latest published documentation is hosted [here](https://jiant-dev.github.io/jiant/).
 
 ##### [Optional] Build from source and view documentation locally:
 1. run `make clean html` in this directory.


### PR DESCRIPTION
Moved jiant dev repo to jiant-dev org, this PR updates links in docs to point to the new location.