### PR TITLE
Turn off codecov during preliminary dev work

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+status:
+  project: false
+  patch: false 


### PR DESCRIPTION
We're trying to expedite the process of loading code into the project from external sources, we're disabling codecov checks to relax the test coverage monitoring while we do that.