### PR TITLE
Add TimeDependentProbMultiTaskSampler

### DIFF
--- a/jiant/proj/main/components/task_sampler.py
+++ b/jiant/proj/main/components/task_sampler.py
@@ -88,6 +88,24 @@ class TemperatureMultiTaskSampler(BaseMultiTaskSampler):
 
 
 class TimeDependentProbMultiTaskSampler(BaseMultiTaskSampler):
+    """Multi-task Sampler with different task sampling probabilities over time
+
+    We describe the individual unnormalized probabilities using numexpr expressions,
+    using t as the variable, e.g.:
+    * 1             (constant)
+    * 2 * t         (linear)
+    * 1/sqrt(t)     (inverse square-root)
+
+    These are computed for all tasks for each time step, and then normalized to sum to 1.
+
+    Attributes:
+        task_dict: Dictionary of tasks
+        rng: Random seed, or NumPy RandomState for sampling
+        task_to_unnormalized_prob_funcs_dict: map from task names to strings, which are
+                                              numexpr expressions
+        max_steps: Maximum number of steps allows (in the case where some functions
+                   are not valid after a given t.
+    """
     def __init__(
         self,
         task_dict: dict,
@@ -171,7 +189,7 @@ def create_task_sampler(
             examples_cap=sampler_config["examples_cap"],
         )
     elif sampler_type == "TimeDependentProbMultiTaskSampler":
-        assert len(sampler_config) in 4
+        assert len(sampler_config) == 3
         return TimeDependentProbMultiTaskSampler(
             task_dict=task_dict,
             rng=rng,

--- a/jiant/proj/main/components/task_sampler.py
+++ b/jiant/proj/main/components/task_sampler.py
@@ -118,8 +118,7 @@ class TimeDependentProbMultiTaskSampler(BaseMultiTaskSampler):
 
         for i, task_name in enumerate(self.task_names):
             p_ls[i] = numexpr.evaluate(
-                self.task_to_unnormalized_prob_funcs_dict[task_name],
-                local_dict={"t": t},
+                self.task_to_unnormalized_prob_funcs_dict[task_name], local_dict={"t": t},
             )
         p_ls /= p_ls.sum()
         return p_ls

--- a/jiant/proj/main/components/task_sampler.py
+++ b/jiant/proj/main/components/task_sampler.py
@@ -172,14 +172,14 @@ def create_task_sampler(
             examples_cap=sampler_config["examples_cap"],
         )
     elif sampler_type == "TimeDependentProbMultiTaskSampler":
-        assert len(sampler_config) in (3, 4)
+        assert len(sampler_config) in 4
         return TimeDependentProbMultiTaskSampler(
             task_dict=task_dict,
             rng=rng,
             task_to_unnormalized_prob_funcs_dict=sampler_config[
                 "task_to_unnormalized_prob_funcs_dict"
             ],
-            max_steps=sampler_config.get("max_steps", None),
+            max_steps=sampler_config["max_steps"],
         )
     else:
         raise KeyError(sampler_type)

--- a/jiant/proj/main/components/task_sampler.py
+++ b/jiant/proj/main/components/task_sampler.py
@@ -106,6 +106,7 @@ class TimeDependentProbMultiTaskSampler(BaseMultiTaskSampler):
         max_steps: Maximum number of steps allows (in the case where some functions
                    are not valid after a given t.
     """
+
     def __init__(
         self,
         task_dict: dict,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 attrs==19.3.0
 bs4==0.0.1
 jsonnet==0.15.0
+numexpr==2.7.1
 numpy==1.18.4
 pandas==1.0.3
 sacremoses==0.0.43

--- a/tests/proj/main/components/test_task_sampler.py
+++ b/tests/proj/main/components/test_task_sampler.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+import jiant.proj.main.components.task_sampler as task_sampler
+
+
+def test_time_dependent_prob_multitask_sampler_const_p():
+    sampler = task_sampler.TimeDependentProbMultiTaskSampler(
+        task_dict={
+            "rte": None,
+            "mnli": None,
+            "squad_v1": None,
+        },
+        rng=0,
+        task_to_unnormalized_prob_funcs_dict={
+            "rte": "1",
+            "mnli": "1",
+            "squad_v1": "1",
+        },
+    )
+    gold_p = np.ones(3) / 3
+    assert np.array_equal(sampler.get_task_p(0), gold_p)
+    assert np.array_equal(sampler.get_task_p(500), gold_p)
+    assert np.array_equal(sampler.get_task_p(999), gold_p)
+
+
+def test_time_dependent_prob_multitask_sampler_variable_p():
+    sampler = task_sampler.TimeDependentProbMultiTaskSampler(
+        task_dict={
+            "rte": None,
+            "mnli": None,
+            "squad_v1": None,
+        },
+        rng=0,
+        task_to_unnormalized_prob_funcs_dict={
+            "rte": "1",
+            "mnli": "1 - t/1000",
+            "squad_v1": "exp(t/1000)",
+        },
+    )
+    assert np.array_equal(sampler.get_task_p(0), np.ones(3) / 3)
+    assert np.allclose(sampler.get_task_p(500), np.array([0.31758924, 0.15879462, 0.52361614]))
+    assert np.allclose(sampler.get_task_p(999), np.array([2.69065663e-01, 2.69065663e-04, 7.30665271e-01]))
+
+
+def test_time_dependent_prob_multitask_sampler_handles_max_steps():
+    sampler_1 = task_sampler.TimeDependentProbMultiTaskSampler(
+        task_dict={"rte": None},
+        rng=0,
+        task_to_unnormalized_prob_funcs_dict={"rte": "1"},
+    )
+    sampler_2 = task_sampler.TimeDependentProbMultiTaskSampler(
+        task_dict={"rte": None},
+        rng=0,
+        task_to_unnormalized_prob_funcs_dict={"rte": "1"},
+        max_steps=10,
+    )
+    for i in range(10):
+        sampler_1.pop()
+        sampler_2.pop()
+    sampler_1.pop()
+    with pytest.raises(IndexError):
+        sampler_2.pop()

--- a/tests/proj/main/components/test_task_sampler.py
+++ b/tests/proj/main/components/test_task_sampler.py
@@ -61,3 +61,5 @@ def test_time_dependent_prob_multitask_sampler_handles_max_steps():
     sampler_1.pop()
     with pytest.raises(IndexError):
         sampler_2.pop()
+    sampler_2.reset_counter()
+    sampler_2.pop()


### PR DESCRIPTION
* **Introduces new dependency: `numexpr`**
* Adds new task sampler `TimeDependentProbMultiTaskSampler`, which uses `numexpr` to evaluate mathematical expressions for determining the task sampling rate
* Adds tests for `TimeDependentProbMultiTaskSampler`