### PR TITLE
Added getter for ccg test examples

### DIFF
--- a/jiant/tasks/lib/ccg.py
+++ b/jiant/tasks/lib/ccg.py
@@ -145,7 +145,7 @@ class CCGTask(Task):
         return self._create_examples(self.val_path, set_type="val")
 
     def get_test_examples(self):
-        raise NotImplementedError()
+        return self._create_examples(path=self.test_path, set_type="test")
 
     def get_tags_to_id(self):
         tags_to_id = read_json(self.path_dict["tags_to_id"])


### PR DESCRIPTION
The CCG task was missing a getter for test examples and this has been added in this PR. The method was tested and run successfully using tokenize_and_cache.py.