### PR TITLE
Add core sequence alignment functionality from jiant1

### DIFF
--- a/jiant/utils/retokenize.py
+++ b/jiant/utils/retokenize.py
@@ -1,0 +1,431 @@
+# Retokenization helpers.
+# Use this to project span annotations from one tokenization to another.
+#
+# NOTE: please don't make this depend on any other jiant/ libraries; it would
+# be nice to opensource this as a standalone utility.
+#
+# Current implementation is not fast; TODO to profile this and see why.
+
+import functools
+import re
+from io import StringIO
+from typing import Iterable, List, NewType, Sequence, Text, Tuple, Type, Union
+
+import numpy as np
+from nltk.tokenize.simple import SpaceTokenizer
+from scipy import sparse
+
+# Use https://pypi.org/project/python-Levenshtein/ for fast alignment.
+# install with: pip install python-Levenshtein
+from Levenshtein.StringMatcher import StringMatcher
+
+from jiant.utils.tokenizers import get_tokenizer, Tokenizer
+from jiant.utils.utils import unescape_moses, transpose_list_of_lists
+
+
+# Tokenizer instance for internal use.
+_SIMPLE_TOKENIZER = SpaceTokenizer()
+_SEP = " "  # should match separator used by _SIMPLE_TOKENIZER
+
+# Type alias for internal matricies
+Matrix = NewType("Matrix", Union[Type[sparse.csr_matrix], Type[np.ndarray]])
+
+_DTYPE = np.int32
+
+
+def _mat_from_blocks_dense(mb, n_chars_src, n_chars_tgt):
+    M = np.zeros((n_chars_src, n_chars_tgt), dtype=_DTYPE)
+    for i in range(len(mb)):
+        b = mb[i]  # current block
+        # Fill in-between this block and last block
+        if i > 0:
+            lb = mb[i - 1]  # last block
+            s0 = lb[0] + lb[2]  # top
+            e0 = b[0]  # bottom
+            s1 = lb[1] + lb[2]  # left
+            e1 = b[1]  # right
+            M[s0:e0, s1:e1] = 1
+        # Fill matching region on diagonal
+        M[b[0] : b[0] + b[2], b[1] : b[1] + b[2]] = 2 * np.identity(b[2], dtype=_DTYPE)
+    return M
+
+
+def _mat_from_blocks_sparse(mb, n_chars_src, n_chars_tgt):
+    ridxs = []
+    cidxs = []
+    data = []
+    for i, b in enumerate(mb):
+        # Fill in-between this block and last block
+        if i > 0:
+            lb = mb[i - 1]  # last block
+            s0 = lb[0] + lb[2]  # top
+            l0 = b[0] - s0  # num rows
+            s1 = lb[1] + lb[2]  # left
+            l1 = b[1] - s1  # num cols
+            idxs = np.indices((l0, l1))
+            ridxs.extend((s0 + idxs[0]).flatten())  # row indices
+            cidxs.extend((s1 + idxs[1]).flatten())  # col indices
+            data.extend(np.ones(l0 * l1, dtype=_DTYPE))
+
+        # Fill matching region on diagonal
+        ridxs.extend(range(b[0], b[0] + b[2]))
+        cidxs.extend(range(b[1], b[1] + b[2]))
+        data.extend(2 * np.ones(b[2], dtype=_DTYPE))
+    M = sparse.csr_matrix((data, (ridxs, cidxs)), shape=(n_chars_src, n_chars_tgt))
+    return M
+
+
+def _mat_from_spans_dense(spans: Sequence[Tuple[int, int]], n_chars: int) -> Matrix:
+    """Construct a token-to-char matrix from a list of char spans."""
+    M = np.zeros((len(spans), n_chars), dtype=_DTYPE)
+    for i, s in enumerate(spans):
+        M[i, s[0] : s[1]] = 1
+    return M
+
+
+def _mat_from_spans_sparse(spans: Sequence[Tuple[int, int]], n_chars: int) -> Matrix:
+    """Construct a token-to-char matrix from a list of char spans."""
+    ridxs = []
+    cidxs = []
+    for i, s in enumerate(spans):
+        ridxs.extend([i] * (s[1] - s[0]))  # repeat token index
+        cidxs.extend(range(s[0], s[1]))  # char indices
+        #  assert len(ridxs) == len(cidxs)
+    data = np.ones(len(ridxs), dtype=_DTYPE)
+    return sparse.csr_matrix((data, (ridxs, cidxs)), shape=(len(spans), n_chars))
+
+
+def realign_spans(record, tokenizer_name):
+    """
+    Builds the indices alignment while also tokenizing the input
+    piece by piece.
+    Currently, SentencePiece (for XLNet), WPM (for BERT), BPE (for GPT/XLM),
+    ByteBPE (for RoBERTa/GPT-2) and Moses (for Transformer-XL and default) tokenization are
+    supported.
+
+    Parameters
+    -----------------------
+        record: dict with the below fields
+            text: str
+            targets: list of dictionaries
+                label: bool
+                span1_index: int, start index of first span
+                span1_text: str, text of first span
+                span2_index: int, start index of second span
+                span2_text: str, text of second span
+        tokenizer_name: str
+
+    Returns
+    ------------------------
+        record: dict with the below fields:
+            text: str in tokenized form
+            targets: dictionary with the below fields
+                -label: bool
+                -span_1: (int, int) of token indices
+                -span1_text: str, the string
+                -span2: (int, int) of token indices
+                -span2_text: str, the string
+    """
+
+    # find span indices and text
+    text = record["text"].split()
+    span1 = record["target"]["span1_index"]
+    span1_text = record["target"]["span1_text"]
+    span2 = record["target"]["span2_index"]
+    span2_text = record["target"]["span2_text"]
+
+    # construct end spans given span text space-tokenized length
+    span1 = [span1, span1 + len(span1_text.strip().split())]
+    span2 = [span2, span2 + len(span2_text.strip().split())]
+    indices = [span1, span2]
+
+    sorted_indices = sorted(indices, key=lambda x: x[0])
+    current_tokenization = []
+    span_mapping = {}
+
+    # align first span to tokenized text
+    aligner_fn = get_aligner_fn(tokenizer_name)
+    _, new_tokens = aligner_fn(" ".join(text[: sorted_indices[0][0]]))
+    current_tokenization.extend(new_tokens)
+    new_span1start = len(current_tokenization)
+    _, span_tokens = aligner_fn(" ".join(text[sorted_indices[0][0] : sorted_indices[0][1]]))
+    current_tokenization.extend(span_tokens)
+    new_span1end = len(current_tokenization)
+    span_mapping[sorted_indices[0][0]] = [new_span1start, new_span1end]
+
+    # re-indexing second span
+    _, new_tokens = aligner_fn(" ".join(text[sorted_indices[0][1] : sorted_indices[1][0]]))
+    current_tokenization.extend(new_tokens)
+    new_span2start = len(current_tokenization)
+    _, span_tokens = aligner_fn(" ".join(text[sorted_indices[1][0] : sorted_indices[1][1]]))
+    current_tokenization.extend(span_tokens)
+    new_span2end = len(current_tokenization)
+    span_mapping[sorted_indices[1][0]] = [new_span2start, new_span2end]
+
+    # save back into record
+    _, all_text = aligner_fn(" ".join(text))
+    record["target"]["span1"] = span_mapping[record["target"]["span1_index"]]
+    record["target"]["span2"] = span_mapping[record["target"]["span2_index"]]
+    record["text"] = " ".join(all_text)
+    return record
+
+
+class TokenAligner(object):
+    """Align two similiar tokenizations.
+
+    Usage:
+        ta = TokenAligner(source_tokens, target_tokens)
+        target_span = ta.project_span(*source_span)
+
+    Uses Levenshtein distance to align two similar tokenizations, and provide
+    facilities to project indices and spans from the source tokenization to the
+    target.
+
+    Let source contain m tokens and M chars, and target contain n tokens and N
+    chars. The token alignment is treated as a (sparse) m x n adjacency matrix
+    T representing the bipartite graph between the source and target tokens.
+
+    This is constructed by performing a character-level alignment using
+    Levenshtein distance to obtain a (M x N) character adjacency matrix C. We
+    then construct token-to-character matricies U (m x M) and V (n x N) and
+    construct T as:
+        T = (U C V')
+    where V' denotes the transpose.
+
+    Spans of non-aligned bytes are assumed to contain a many-to-many alignment
+    of all chars in that range. This can lead to unwanted alignments if, for
+    example, two consecutive tokens are mapped to escape sequences:
+        source: ["'s", "["]
+        target: ["&apos;", "s", "&#91;"]
+    In the above case, "'s'" may be spuriously aligned to "&apos;" while "["
+    has no character match with "s" or "&#91;", and so is aligned to both. To
+    make a correct alignment more likely, ensure that the characters in target
+    correspond as closely as possible to those in source. For example, the
+    following will align correctly:
+        source: ["'s", "["]
+        target: ["'", "s", "["]
+    """
+
+    def token_to_char(self, text: str) -> Matrix:
+        spans = _SIMPLE_TOKENIZER.span_tokenize(text)
+        # TODO(iftenney): compare performance of these implementations.
+        return _mat_from_spans_sparse(tuple(spans), len(text))
+        #  return _mat_from_spans_dense(tuple(spans), len(text))
+
+    def _mat_from_blocks(
+        self, mb: Sequence[Tuple[int, int, int]], n_chars_src: int, n_chars_tgt: int
+    ) -> Matrix:
+        """Construct a char-to-char matrix from a list of matching blocks.
+
+        mb is a sequence of (s1, s2, n_char) tuples, where s1 and s2 are the
+        start indices in the first and second sequence, and n_char is the
+        length of the block.
+        """
+        # TODO(iftenney): compare performance of these implementations.
+        #  return _mat_from_blocks_sparse(mb, n_chars_src, n_chars_tgt)
+        return _mat_from_blocks_dense(mb, n_chars_src, n_chars_tgt)
+
+    def char_to_char(self, source: str, target: str) -> Matrix:
+        # Run Levenshtein at character level.
+        sm = StringMatcher(seq1=source, seq2=target)
+        mb = sm.get_matching_blocks()
+        return self._mat_from_blocks(mb, len(source), len(target))
+
+    def __init__(self, source: Union[Iterable[str], str], target: Union[Iterable[str], str]):
+        # Coerce source and target to space-delimited string.
+        if not isinstance(source, str):
+            source = _SEP.join(source)
+        if not isinstance(target, str):
+            target = _SEP.join(target)
+
+        self.U = self.token_to_char(source)  # (M x m)
+        self.V = self.token_to_char(target)  # (N x n)
+        # Character transfer matrix (M x N)
+        self.C = self.char_to_char(source, target)
+        # Token transfer matrix (m x n)
+        self.T = self.U * self.C * self.V.T
+        #  self.T = self.U.dot(self.C).dot(self.V.T)
+
+    def __str__(self):
+        return self.pprint()
+
+    def pprint(self, src_tokens=None, tgt_tokens=None) -> str:
+        """Render as alignment table: src -> [tgts]"""
+        output = StringIO()
+        output.write("{:s}({:d}, {:d}):\n".format(self.__class__.__name__, *self.T.shape))
+        for i in range(self.T.shape[0]):
+            targs = sorted(list(self.project_tokens(i)))
+            output.write("  {:d} -> {:s}".format(i, str(targs)))
+            if src_tokens is not None and tgt_tokens is not None:
+                tgt_list = [tgt_tokens[j] for j in targs]
+                output.write("\t'{:s}' -> {:s}".format(src_tokens[i], str(tgt_list)))
+            output.write("\n")
+        return output.getvalue()
+
+    def project_tokens(self, idxs: Union[int, Sequence[int]]) -> Sequence[int]:
+        """Project source token indices to target token indices."""
+        if isinstance(idxs, int):
+            idxs = [idxs]
+        return self.T[idxs].nonzero()[1]  # column indices
+
+    def project_span(self, start, end) -> Tuple[int, int]:
+        """Project a span from source to target.
+
+        Span end is taken to be exclusive, so this actually projects end - 1
+        and maps back to an exclusive target span.
+        """
+        tgt_idxs = self.project_tokens([start, end - 1])
+        return min(tgt_idxs), max(tgt_idxs) + 1
+
+
+##
+# Aligner functions. These take a raw string and return a tuple
+# of a TokenAligner instance and a list of tokens.
+##
+
+
+def space_tokenize_with_eow(sentence):
+    """Add </w> markers to ensure word-boundary alignment."""
+    return [t + "</w>" for t in sentence.split()]
+
+
+def process_wordpiece_for_alignment(t):
+    """Add <w> markers to ensure word-boundary alignment."""
+    if t.startswith("##"):
+        return re.sub(r"^##", "", t)
+    else:
+        return "<w>" + t
+
+
+def process_sentencepiece_for_alignment(t):
+    """Add <w> markers to ensure word-boundary alignment."""
+    if t.startswith("▁"):
+        return "<w>" + re.sub(r"^▁", "", t)
+    else:
+        return t
+
+
+def process_bytebpe_for_alignment(t):
+    """Add <w> markers to ensure word-boundary alignment."""
+    if t.startswith("Ġ"):
+        return "<w>" + re.sub(r"^Ġ", "", t)
+    else:
+        return t
+
+
+def space_tokenize_with_bow(sentence):
+    """Add <w> markers to ensure word-boundary alignment."""
+    return ["<w>" + t for t in sentence.split()]
+
+
+def align_moses(text: Text) -> Tuple[TokenAligner, List[Text]]:
+    """Aligner fn for Moses tokenizer, used in Transformer-XL
+    """
+    MosesTokenizer = get_tokenizer("MosesTokenizer")
+    moses_tokens = MosesTokenizer.tokenize(text)
+    cleaned_moses_tokens = unescape_moses(moses_tokens)
+    ta = TokenAligner(text, cleaned_moses_tokens)
+    return ta, moses_tokens
+
+
+def align_wpm(
+    text: Text, wpm_tokenizer: Tokenizer, do_lower_case: bool
+) -> Tuple[TokenAligner, List[Text]]:
+    """Alignment fn for WPM tokenizer, used in BERT
+    """
+    # If using lowercase, do this for the source tokens for better matching.
+    bow_tokens = space_tokenize_with_bow(text.lower() if do_lower_case else text)
+    wpm_tokens = wpm_tokenizer.tokenize(text)
+
+    # Align using <w> markers for stability w.r.t. word boundaries.
+    modified_wpm_tokens = list(map(process_wordpiece_for_alignment, wpm_tokens))
+    ta = TokenAligner(bow_tokens, modified_wpm_tokens)
+    return ta, wpm_tokens
+
+
+def align_sentencepiece(
+    text: Text, sentencepiece_tokenizer: Tokenizer
+) -> Tuple[TokenAligner, List[Text]]:
+    """Alignment fn for SentencePiece Tokenizer, used in XLNET and ALBERT
+    """
+    bow_tokens = space_tokenize_with_bow(text)
+    sentencepiece_tokens = sentencepiece_tokenizer.tokenize(text)
+
+    modified_sentencepiece_tokens = list(
+        map(process_sentencepiece_for_alignment, sentencepiece_tokens)
+    )
+    ta = TokenAligner(bow_tokens, modified_sentencepiece_tokens)
+    return ta, sentencepiece_tokens
+
+
+def align_bpe(text: Text, bpe_tokenizer: Tokenizer) -> Tuple[TokenAligner, List[Text]]:
+    """Alignment fn for BPE tokenizer, used in GPT and XLM
+    """
+    eow_tokens = space_tokenize_with_eow(text.lower())
+    bpe_tokens = bpe_tokenizer.tokenize(text)
+    ta = TokenAligner(eow_tokens, bpe_tokens)
+    return ta, bpe_tokens
+
+
+def align_bytebpe(text: Text, bytebpe_tokenizer: Tokenizer) -> Tuple[TokenAligner, List[Text]]:
+    """Alignment fn for Byte-level BPE tokenizer, used in GPT-2 and RoBERTa
+    """
+    bow_tokens = space_tokenize_with_bow(text)
+    bytebpe_tokens = bytebpe_tokenizer.tokenize(text)
+
+    if len(bytebpe_tokens) > 0:
+        bytebpe_tokens[0] = "Ġ" + bytebpe_tokens[0]
+    modified_bytebpe_tokens = list(map(process_bytebpe_for_alignment, bytebpe_tokens))
+    ta = TokenAligner(bow_tokens, modified_bytebpe_tokens)
+    if len(bytebpe_tokens) > 0:
+        bytebpe_tokens[0] = re.sub(r"^Ġ", "", bytebpe_tokens[0])
+    return ta, bytebpe_tokens
+
+
+def get_aligner_fn(tokenizer_name: Text):
+    """Given the tokenzier_name, return the corresponding alignment function.
+    An alignment function modified the tokenized input to make it close to source token,
+    and choose a space tokenizer with its word-boundary at the same side as tokenizer_name,
+    hence the source (from space tokenizer) and target (from tokenizer_name) is sufficiently close.
+    Use TokenAligner to project token index from source to target.
+    """
+    if tokenizer_name == "MosesTokenizer" or tokenizer_name.startswith("transfo-xl-"):
+        return align_moses
+    elif tokenizer_name.startswith("bert-"):
+        do_lower_case = tokenizer_name.endswith("uncased")
+        wpm_tokenizer = get_tokenizer(tokenizer_name)
+        return functools.partial(
+            align_wpm, wpm_tokenizer=wpm_tokenizer, do_lower_case=do_lower_case
+        )
+    elif tokenizer_name.startswith("openai-gpt") or tokenizer_name.startswith("xlm-mlm-en-"):
+        bpe_tokenizer = get_tokenizer(tokenizer_name)
+        return functools.partial(align_bpe, bpe_tokenizer=bpe_tokenizer)
+    elif tokenizer_name.startswith("xlnet-") or tokenizer_name.startswith("albert-"):
+        sentencepiece_tokenizer = get_tokenizer(tokenizer_name)
+        return functools.partial(
+            align_sentencepiece, sentencepiece_tokenizer=sentencepiece_tokenizer
+        )
+    elif tokenizer_name.startswith("roberta-") or tokenizer_name.startswith("gpt2"):
+        bytebpe_tokenizer = get_tokenizer(tokenizer_name)
+        return functools.partial(align_bytebpe, bytebpe_tokenizer=bytebpe_tokenizer)
+    else:
+        raise ValueError(f"Unsupported tokenizer '{tokenizer_name}'")
+
+
+def space_tokenize_with_spans(text):
+    space_tokens = text.split()
+    result = []
+    i = 0
+    for token in space_tokens:
+        start = text[i:].find(token)
+        end = start + len(token)
+        result.append((token, i + start, i + end))
+        i += end
+    return result
+
+
+def find_space_token_span(space_tokens_with_spans, char_start, char_end):
+    starts, ends = transpose_list_of_lists(space_tokens_with_spans)[1:]
+    tok_start = np.clip((np.array(starts) > char_start).argmax() - 1, 0, None)
+    tok_end = (np.array(ends) > (char_end - 1)).argmax() + 1
+    return tok_start, tok_end

--- a/jiant/utils/retokenize.py
+++ b/jiant/utils/retokenize.py
@@ -1,34 +1,18 @@
-# Retokenization helpers.
-# Use this to project span annotations from one tokenization to another.
-#
-# NOTE: please don't make this depend on any other jiant/ libraries; it would
-# be nice to opensource this as a standalone utility.
-#
-# Current implementation is not fast; TODO to profile this and see why.
+"""Retokenization helpers
 
-import functools
-import re
-from io import StringIO
-from typing import Iterable, List, NewType, Sequence, Text, Tuple, Type, Union
+This module provides helpers for projecting span annotations from one tokenization to another.
 
-import numpy as np
-from nltk.tokenize.simple import SpaceTokenizer
-from scipy import sparse
+Notes:
+    * Code is ported from https://github.com/nyu-mll/jiant/blob/master/jiant/utils/retokenize.py
+    * Please keep this code as a standalone utility; don't make this module depend on jiant modules.
 
-# Use https://pypi.org/project/python-Levenshtein/ for fast alignment.
-# install with: pip install python-Levenshtein
+"""
+from typing import Iterable, Sequence, Tuple, Union
+
 from Levenshtein.StringMatcher import StringMatcher
+from nltk.tokenize.util import string_span_tokenize
+import numpy as np
 
-from jiant.utils.tokenizers import get_tokenizer, Tokenizer
-from jiant.utils.utils import unescape_moses, transpose_list_of_lists
-
-
-# Tokenizer instance for internal use.
-_SIMPLE_TOKENIZER = SpaceTokenizer()
-_SEP = " "  # should match separator used by _SIMPLE_TOKENIZER
-
-# Type alias for internal matricies
-Matrix = NewType("Matrix", Union[Type[sparse.csr_matrix], Type[np.ndarray]])
 
 _DTYPE = np.int32
 
@@ -50,32 +34,7 @@ def _mat_from_blocks_dense(mb, n_chars_src, n_chars_tgt):
     return M
 
 
-def _mat_from_blocks_sparse(mb, n_chars_src, n_chars_tgt):
-    ridxs = []
-    cidxs = []
-    data = []
-    for i, b in enumerate(mb):
-        # Fill in-between this block and last block
-        if i > 0:
-            lb = mb[i - 1]  # last block
-            s0 = lb[0] + lb[2]  # top
-            l0 = b[0] - s0  # num rows
-            s1 = lb[1] + lb[2]  # left
-            l1 = b[1] - s1  # num cols
-            idxs = np.indices((l0, l1))
-            ridxs.extend((s0 + idxs[0]).flatten())  # row indices
-            cidxs.extend((s1 + idxs[1]).flatten())  # col indices
-            data.extend(np.ones(l0 * l1, dtype=_DTYPE))
-
-        # Fill matching region on diagonal
-        ridxs.extend(range(b[0], b[0] + b[2]))
-        cidxs.extend(range(b[1], b[1] + b[2]))
-        data.extend(2 * np.ones(b[2], dtype=_DTYPE))
-    M = sparse.csr_matrix((data, (ridxs, cidxs)), shape=(n_chars_src, n_chars_tgt))
-    return M
-
-
-def _mat_from_spans_dense(spans: Sequence[Tuple[int, int]], n_chars: int) -> Matrix:
+def _mat_from_spans_dense(spans: Sequence[Tuple[int, int]], n_chars: int) -> np.ndarray:
     """Construct a token-to-char matrix from a list of char spans."""
     M = np.zeros((len(spans), n_chars), dtype=_DTYPE)
     for i, s in enumerate(spans):
@@ -83,349 +42,168 @@ def _mat_from_spans_dense(spans: Sequence[Tuple[int, int]], n_chars: int) -> Mat
     return M
 
 
-def _mat_from_spans_sparse(spans: Sequence[Tuple[int, int]], n_chars: int) -> Matrix:
-    """Construct a token-to-char matrix from a list of char spans."""
-    ridxs = []
-    cidxs = []
-    for i, s in enumerate(spans):
-        ridxs.extend([i] * (s[1] - s[0]))  # repeat token index
-        cidxs.extend(range(s[0], s[1]))  # char indices
-        #  assert len(ridxs) == len(cidxs)
-    data = np.ones(len(ridxs), dtype=_DTYPE)
-    return sparse.csr_matrix((data, (ridxs, cidxs)), shape=(len(spans), n_chars))
+def token_to_char(text: str, sep=" ") -> np.ndarray:
+    """Takes a string, space tokenizes the string, and returns a mapping from tokens to chars.
 
+    Examples:
+        >>> token_to_char("testing 1, 2, 3")
+        # produces a (m) token by (M) char matrix:
 
-def realign_spans(record, tokenizer_name):
+                   t e s t i n g   1 ,   2 ,   3
+         testing [[1 1 1 1 1 1 1 0 0 0 0 0 0 0 0]
+              1,  [0 0 0 0 0 0 0 0 1 1 0 0 0 0 0]
+              2,  [0 0 0 0 0 0 0 0 0 0 0 1 1 0 0]
+              3   [0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]]
+
+    Args:
+        text (str): string to tokenize and build the token to char mapping.
+
+    Returns:
+        np.ndarray mapping from (m) tokens to (M) chars.
+
     """
-    Builds the indices alignment while also tokenizing the input
-    piece by piece.
-    Currently, SentencePiece (for XLNet), WPM (for BERT), BPE (for GPT/XLM),
-    ByteBPE (for RoBERTa/GPT-2) and Moses (for Transformer-XL and default) tokenization are
-    supported.
+    spans = string_span_tokenize(text, sep=sep)
+    return _mat_from_spans_dense(tuple(spans), len(text))
 
-    Parameters
-    -----------------------
-        record: dict with the below fields
-            text: str
-            targets: list of dictionaries
-                label: bool
-                span1_index: int, start index of first span
-                span1_text: str, text of first span
-                span2_index: int, start index of second span
-                span2_text: str, text of second span
-        tokenizer_name: str
 
-    Returns
-    ------------------------
-        record: dict with the below fields:
-            text: str in tokenized form
-            targets: dictionary with the below fields
-                -label: bool
-                -span_1: (int, int) of token indices
-                -span1_text: str, the string
-                -span2: (int, int) of token indices
-                -span2_text: str, the string
+def _mat_from_blocks(
+    mb: Sequence[Tuple[int, int, int]], n_chars_src: int, n_chars_tgt: int
+) -> np.ndarray:
+    """Construct a char-to-char matrix from a list of matching blocks.
+
+    mb is a sequence of (s1, s2, n_char) tuples, where s1 and s2 are the start indices in the
+    first and second sequence, and n_char is the length of the block.
+
+    Args:
+        mb: list of triples of non-overlapping matching subsequences in source str and target.
+        n_chars_src (int): number of chars in the source string.
+        n_chars_tgt (int): number of chars in the target string.
+
+    Returns:
+        np.ndarray adjacency matrix mapping chars in the source str to chars in the target str.
+
     """
+    return _mat_from_blocks_dense(mb, n_chars_src, n_chars_tgt)
 
-    # find span indices and text
-    text = record["text"].split()
-    span1 = record["target"]["span1_index"]
-    span1_text = record["target"]["span1_text"]
-    span2 = record["target"]["span2_index"]
-    span2_text = record["target"]["span2_text"]
 
-    # construct end spans given span text space-tokenized length
-    span1 = [span1, span1 + len(span1_text.strip().split())]
-    span2 = [span2, span2 + len(span2_text.strip().split())]
-    indices = [span1, span2]
+def char_to_char(source: str, target: str) -> np.ndarray:
+    """Find the character adjacency matrix mapping source string chars to target string chars.
 
-    sorted_indices = sorted(indices, key=lambda x: x[0])
-    current_tokenization = []
-    span_mapping = {}
+    Uses StringMatcher from Levenshtein package to find non-overlapping matching subsequences in
+    input strings. Uses the result to create a character adjacency matrix from source to target.
+    (https://docs.python.org/2/library/difflib.html#difflib.SequenceMatcher.get_matching_blocks)
 
-    # align first span to tokenized text
-    aligner_fn = get_aligner_fn(tokenizer_name)
-    _, new_tokens = aligner_fn(" ".join(text[: sorted_indices[0][0]]))
-    current_tokenization.extend(new_tokens)
-    new_span1start = len(current_tokenization)
-    _, span_tokens = aligner_fn(" ".join(text[sorted_indices[0][0] : sorted_indices[0][1]]))
-    current_tokenization.extend(span_tokens)
-    new_span1end = len(current_tokenization)
-    span_mapping[sorted_indices[0][0]] = [new_span1start, new_span1end]
+    Args:
+        source (str): string of source chars.
+        target (str): string of target chars.
 
-    # re-indexing second span
-    _, new_tokens = aligner_fn(" ".join(text[sorted_indices[0][1] : sorted_indices[1][0]]))
-    current_tokenization.extend(new_tokens)
-    new_span2start = len(current_tokenization)
-    _, span_tokens = aligner_fn(" ".join(text[sorted_indices[1][0] : sorted_indices[1][1]]))
-    current_tokenization.extend(span_tokens)
-    new_span2end = len(current_tokenization)
-    span_mapping[sorted_indices[1][0]] = [new_span2start, new_span2end]
+    Returns:
+        np.ndarray adjacency matrix mapping chars in the source str to chars in the target str.
 
-    # save back into record
-    _, all_text = aligner_fn(" ".join(text))
-    record["target"]["span1"] = span_mapping[record["target"]["span1_index"]]
-    record["target"]["span2"] = span_mapping[record["target"]["span2_index"]]
-    record["text"] = " ".join(all_text)
-    return record
+    """
+    sm = StringMatcher(seq1=source, seq2=target)
+    mb = sm.get_matching_blocks()
+    return _mat_from_blocks(mb, len(source), len(target))
 
 
 class TokenAligner(object):
     """Align two similiar tokenizations.
 
+    Args:
+        source (Union[Iterable[str], str]): Source text tokens or string.
+        target (Union[Iterable[str], str]): Target text tokens or string.
+
     Usage:
         ta = TokenAligner(source_tokens, target_tokens)
         target_span = ta.project_span(*source_span)
 
-    Uses Levenshtein distance to align two similar tokenizations, and provide
-    facilities to project indices and spans from the source tokenization to the
-    target.
+    Uses Levenshtein distance to align two similar tokenizations, and provide facilities to project
+    indices and spans from the source tokenization to the target.
 
-    Let source contain m tokens and M chars, and target contain n tokens and N
-    chars. The token alignment is treated as a (sparse) m x n adjacency matrix
-    T representing the bipartite graph between the source and target tokens.
+    Let source contain m tokens and M chars, and target contain n tokens and N chars. The token
+    alignment is treated as a (sparse) m x n adjacency matrix T representing the bipartite graph
+    between the source and target tokens.
 
-    This is constructed by performing a character-level alignment using
-    Levenshtein distance to obtain a (M x N) character adjacency matrix C. We
-    then construct token-to-character matricies U (m x M) and V (n x N) and
-    construct T as:
+    This is constructed by performing a character-level alignment using Levenshtein distance to
+    obtain a (M x N) character adjacency matrix C. We then construct token-to-character matricies
+    U (m x M) and V (n x N) and construct T as:
         T = (U C V')
     where V' denotes the transpose.
 
-    Spans of non-aligned bytes are assumed to contain a many-to-many alignment
-    of all chars in that range. This can lead to unwanted alignments if, for
-    example, two consecutive tokens are mapped to escape sequences:
+    Spans of non-aligned bytes are assumed to contain a many-to-many alignment of all chars in that
+    range. This can lead to unwanted alignments if, for example, two consecutive tokens are mapped
+    to escape sequences:
         source: ["'s", "["]
         target: ["&apos;", "s", "&#91;"]
-    In the above case, "'s'" may be spuriously aligned to "&apos;" while "["
-    has no character match with "s" or "&#91;", and so is aligned to both. To
-    make a correct alignment more likely, ensure that the characters in target
-    correspond as closely as possible to those in source. For example, the
-    following will align correctly:
+    In the above case, "'s'" may be spuriously aligned to "&apos;" while "[" has no character match
+    with "s" or "&#91;", and so is aligned to both. To make a correct alignment more likely, ensure
+    that the characters in target correspond as closely as possible to those in source. For example,
+    the following will align correctly:
         source: ["'s", "["]
         target: ["'", "s", "["]
+
     """
-
-    def token_to_char(self, text: str) -> Matrix:
-        spans = _SIMPLE_TOKENIZER.span_tokenize(text)
-        # TODO(iftenney): compare performance of these implementations.
-        return _mat_from_spans_sparse(tuple(spans), len(text))
-        #  return _mat_from_spans_dense(tuple(spans), len(text))
-
-    def _mat_from_blocks(
-        self, mb: Sequence[Tuple[int, int, int]], n_chars_src: int, n_chars_tgt: int
-    ) -> Matrix:
-        """Construct a char-to-char matrix from a list of matching blocks.
-
-        mb is a sequence of (s1, s2, n_char) tuples, where s1 and s2 are the
-        start indices in the first and second sequence, and n_char is the
-        length of the block.
-        """
-        # TODO(iftenney): compare performance of these implementations.
-        #  return _mat_from_blocks_sparse(mb, n_chars_src, n_chars_tgt)
-        return _mat_from_blocks_dense(mb, n_chars_src, n_chars_tgt)
-
-    def char_to_char(self, source: str, target: str) -> Matrix:
-        # Run Levenshtein at character level.
-        sm = StringMatcher(seq1=source, seq2=target)
-        mb = sm.get_matching_blocks()
-        return self._mat_from_blocks(mb, len(source), len(target))
 
     def __init__(self, source: Union[Iterable[str], str], target: Union[Iterable[str], str]):
         # Coerce source and target to space-delimited string.
         if not isinstance(source, str):
-            source = _SEP.join(source)
+            source = " ".join(source)
         if not isinstance(target, str):
-            target = _SEP.join(target)
-
-        self.U = self.token_to_char(source)  # (M x m)
-        self.V = self.token_to_char(target)  # (N x n)
-        # Character transfer matrix (M x N)
-        self.C = self.char_to_char(source, target)
-        # Token transfer matrix (m x n)
-        self.T = self.U * self.C * self.V.T
-        #  self.T = self.U.dot(self.C).dot(self.V.T)
-
-    def __str__(self):
-        return self.pprint()
-
-    def pprint(self, src_tokens=None, tgt_tokens=None) -> str:
-        """Render as alignment table: src -> [tgts]"""
-        output = StringIO()
-        output.write("{:s}({:d}, {:d}):\n".format(self.__class__.__name__, *self.T.shape))
-        for i in range(self.T.shape[0]):
-            targs = sorted(list(self.project_tokens(i)))
-            output.write("  {:d} -> {:s}".format(i, str(targs)))
-            if src_tokens is not None and tgt_tokens is not None:
-                tgt_list = [tgt_tokens[j] for j in targs]
-                output.write("\t'{:s}' -> {:s}".format(src_tokens[i], str(tgt_list)))
-            output.write("\n")
-        return output.getvalue()
+            target = " ".join(target)
+        self.U = token_to_char(source)
+        self.V = token_to_char(target)  # (n x N)
+        self.C = char_to_char(source, target)  # (M x N)
+        # Token transfer matrix from (m) tokens in source to (n) tokens in the target. Mat value at
+        # index i, j measures the character overlap btwn the ith source token and jth target token.
+        self.T = self.U.dot(self.C).dot(self.V.T)
 
     def project_tokens(self, idxs: Union[int, Sequence[int]]) -> Sequence[int]:
-        """Project source token indices to target token indices."""
+        """Project source token index(s) to target token indices.
+
+        Takes a list of token indices in the source token sequence, and returns the corresponding
+        tokens in the target sequence.
+
+        Args:
+            idxs (Union[int, Sequence[int]]): source token index(s) to get related target indices.
+
+        Examples:
+            >>> source_tokens = ['abc', 'def', 'ghi', 'jkl']
+            >>> target_tokens = ['abc', 'd', 'ef', 'ghi', 'jkl']
+            >>> ta = TokenAligner(source_tokens, target_tokens)
+            >>> print(ta.project_tokens([1, 2]))
+            [1 2 3]
+
+        Returns:
+            List[int] representing the target indices associated with the provided source indices.
+
+        """
         if isinstance(idxs, int):
             idxs = [idxs]
         return self.T[idxs].nonzero()[1]  # column indices
 
     def project_span(self, start, end) -> Tuple[int, int]:
-        """Project a span from source to target.
+        """Project a span from source to target token sequence.
 
-        Span end is taken to be exclusive, so this actually projects end - 1
-        and maps back to an exclusive target span.
+        Notes:
+            Span end is taken to be exclusive, so this actually projects end - 1 and maps back to an
+            exclusive target span.
+
+        Examples:
+            >>> source_tokens = ['abc', 'def', 'ghi', 'jkl']
+            >>> target_tokens = ['abc', 'd', 'ef', 'ghi', 'jkl']
+            >>> ta = TokenAligner(source_tokens, target_tokens)
+            >>> start, end = 0, 2
+            >>> print(ta.project_span(start, end))
+            (0, 3)
+
+        Raises:
+            ValueError if span end index is not greater than start index.
+
+        Returns:
+            Tuple[int, int] representing the target span (span end exclusive) for the source span.
+
         """
+        if start >= end:
+            raise ValueError("provide a valid (end-exclusive) span.")
         tgt_idxs = self.project_tokens([start, end - 1])
         return min(tgt_idxs), max(tgt_idxs) + 1
-
-
-##
-# Aligner functions. These take a raw string and return a tuple
-# of a TokenAligner instance and a list of tokens.
-##
-
-
-def space_tokenize_with_eow(sentence):
-    """Add </w> markers to ensure word-boundary alignment."""
-    return [t + "</w>" for t in sentence.split()]
-
-
-def process_wordpiece_for_alignment(t):
-    """Add <w> markers to ensure word-boundary alignment."""
-    if t.startswith("##"):
-        return re.sub(r"^##", "", t)
-    else:
-        return "<w>" + t
-
-
-def process_sentencepiece_for_alignment(t):
-    """Add <w> markers to ensure word-boundary alignment."""
-    if t.startswith("▁"):
-        return "<w>" + re.sub(r"^▁", "", t)
-    else:
-        return t
-
-
-def process_bytebpe_for_alignment(t):
-    """Add <w> markers to ensure word-boundary alignment."""
-    if t.startswith("Ġ"):
-        return "<w>" + re.sub(r"^Ġ", "", t)
-    else:
-        return t
-
-
-def space_tokenize_with_bow(sentence):
-    """Add <w> markers to ensure word-boundary alignment."""
-    return ["<w>" + t for t in sentence.split()]
-
-
-def align_moses(text: Text) -> Tuple[TokenAligner, List[Text]]:
-    """Aligner fn for Moses tokenizer, used in Transformer-XL
-    """
-    MosesTokenizer = get_tokenizer("MosesTokenizer")
-    moses_tokens = MosesTokenizer.tokenize(text)
-    cleaned_moses_tokens = unescape_moses(moses_tokens)
-    ta = TokenAligner(text, cleaned_moses_tokens)
-    return ta, moses_tokens
-
-
-def align_wpm(
-    text: Text, wpm_tokenizer: Tokenizer, do_lower_case: bool
-) -> Tuple[TokenAligner, List[Text]]:
-    """Alignment fn for WPM tokenizer, used in BERT
-    """
-    # If using lowercase, do this for the source tokens for better matching.
-    bow_tokens = space_tokenize_with_bow(text.lower() if do_lower_case else text)
-    wpm_tokens = wpm_tokenizer.tokenize(text)
-
-    # Align using <w> markers for stability w.r.t. word boundaries.
-    modified_wpm_tokens = list(map(process_wordpiece_for_alignment, wpm_tokens))
-    ta = TokenAligner(bow_tokens, modified_wpm_tokens)
-    return ta, wpm_tokens
-
-
-def align_sentencepiece(
-    text: Text, sentencepiece_tokenizer: Tokenizer
-) -> Tuple[TokenAligner, List[Text]]:
-    """Alignment fn for SentencePiece Tokenizer, used in XLNET and ALBERT
-    """
-    bow_tokens = space_tokenize_with_bow(text)
-    sentencepiece_tokens = sentencepiece_tokenizer.tokenize(text)
-
-    modified_sentencepiece_tokens = list(
-        map(process_sentencepiece_for_alignment, sentencepiece_tokens)
-    )
-    ta = TokenAligner(bow_tokens, modified_sentencepiece_tokens)
-    return ta, sentencepiece_tokens
-
-
-def align_bpe(text: Text, bpe_tokenizer: Tokenizer) -> Tuple[TokenAligner, List[Text]]:
-    """Alignment fn for BPE tokenizer, used in GPT and XLM
-    """
-    eow_tokens = space_tokenize_with_eow(text.lower())
-    bpe_tokens = bpe_tokenizer.tokenize(text)
-    ta = TokenAligner(eow_tokens, bpe_tokens)
-    return ta, bpe_tokens
-
-
-def align_bytebpe(text: Text, bytebpe_tokenizer: Tokenizer) -> Tuple[TokenAligner, List[Text]]:
-    """Alignment fn for Byte-level BPE tokenizer, used in GPT-2 and RoBERTa
-    """
-    bow_tokens = space_tokenize_with_bow(text)
-    bytebpe_tokens = bytebpe_tokenizer.tokenize(text)
-
-    if len(bytebpe_tokens) > 0:
-        bytebpe_tokens[0] = "Ġ" + bytebpe_tokens[0]
-    modified_bytebpe_tokens = list(map(process_bytebpe_for_alignment, bytebpe_tokens))
-    ta = TokenAligner(bow_tokens, modified_bytebpe_tokens)
-    if len(bytebpe_tokens) > 0:
-        bytebpe_tokens[0] = re.sub(r"^Ġ", "", bytebpe_tokens[0])
-    return ta, bytebpe_tokens
-
-
-def get_aligner_fn(tokenizer_name: Text):
-    """Given the tokenzier_name, return the corresponding alignment function.
-    An alignment function modified the tokenized input to make it close to source token,
-    and choose a space tokenizer with its word-boundary at the same side as tokenizer_name,
-    hence the source (from space tokenizer) and target (from tokenizer_name) is sufficiently close.
-    Use TokenAligner to project token index from source to target.
-    """
-    if tokenizer_name == "MosesTokenizer" or tokenizer_name.startswith("transfo-xl-"):
-        return align_moses
-    elif tokenizer_name.startswith("bert-"):
-        do_lower_case = tokenizer_name.endswith("uncased")
-        wpm_tokenizer = get_tokenizer(tokenizer_name)
-        return functools.partial(
-            align_wpm, wpm_tokenizer=wpm_tokenizer, do_lower_case=do_lower_case
-        )
-    elif tokenizer_name.startswith("openai-gpt") or tokenizer_name.startswith("xlm-mlm-en-"):
-        bpe_tokenizer = get_tokenizer(tokenizer_name)
-        return functools.partial(align_bpe, bpe_tokenizer=bpe_tokenizer)
-    elif tokenizer_name.startswith("xlnet-") or tokenizer_name.startswith("albert-"):
-        sentencepiece_tokenizer = get_tokenizer(tokenizer_name)
-        return functools.partial(
-            align_sentencepiece, sentencepiece_tokenizer=sentencepiece_tokenizer
-        )
-    elif tokenizer_name.startswith("roberta-") or tokenizer_name.startswith("gpt2"):
-        bytebpe_tokenizer = get_tokenizer(tokenizer_name)
-        return functools.partial(align_bytebpe, bytebpe_tokenizer=bytebpe_tokenizer)
-    else:
-        raise ValueError(f"Unsupported tokenizer '{tokenizer_name}'")
-
-
-def space_tokenize_with_spans(text):
-    space_tokens = text.split()
-    result = []
-    i = 0
-    for token in space_tokens:
-        start = text[i:].find(token)
-        end = start + len(token)
-        result.append((token, i + start, i + end))
-        i += end
-    return result
-
-
-def find_space_token_span(space_tokens_with_spans, char_start, char_end):
-    starts, ends = transpose_list_of_lists(space_tokens_with_spans)[1:]
-    tok_start = np.clip((np.array(starts) > char_start).argmax() - 1, 0, None)
-    tok_end = (np.array(ends) > (char_end - 1)).argmax() + 1
-    return tok_start, tok_end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 attrs==19.3.0
 bs4==0.0.1
 jsonnet==0.15.0
+nltk>=3.4.5
 numexpr==2.7.1
 numpy==1.18.4
 pandas==1.0.3
+python-Levenshtein==0.12.0
 sacremoses==0.0.43
 scikit-learn==0.22.2.post1
 scipy==1.4.1

--- a/tests/utils/test_token_alignment.py
+++ b/tests/utils/test_token_alignment.py
@@ -1,0 +1,561 @@
+import numpy as np
+import pytest
+
+from jiant.utils.retokenize import TokenAligner, token_to_char
+
+
+def test_token_to_char():
+    expected_m = np.array(
+        # T  h  i  s     i  s     a     t  e  s  t
+        [
+            [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],  # This
+            [0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0],  # is
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],  # a
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+        ],  # test
+        dtype=np.int32,
+    )
+    m = token_to_char("This is a test")
+    assert (m == expected_m).all()
+
+
+def test_token_to_char_no_spaces():
+    expected_m = np.array(
+        # T  h  i  s  i  s  a  t  e  s  t
+        [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]],  # Thisisatest
+        dtype=np.int32,
+    )
+    m = token_to_char("Thisisatest")
+    assert (m == expected_m).all()
+
+
+def test_token_to_char_empty_str():
+    expected_m = np.array([[]], dtype=np.int32)
+    m = token_to_char("")
+    assert (m == expected_m).all()
+
+
+def test_token_aligner_project_single_token_index():
+    source_tokens = ["abc", "def", "ghi", "jkl"]
+    target_tokens = ["abc", "d", "ef", "ghi", "jkl"]
+    ta = TokenAligner(source_tokens, target_tokens)
+    m = ta.project_tokens(1)
+    m_expected = np.array([1, 2])
+    assert (m == m_expected).all()
+
+
+def test_token_aligner_project_multiple_token_indices():
+    source_tokens = ["abc", "def", "ghi", "jkl"]
+    target_tokens = ["abc", "d", "ef", "ghi", "jkl"]
+    ta = TokenAligner(source_tokens, target_tokens)
+    m = ta.project_tokens([1, 3])
+    m_expected = np.array([1, 2, 4])
+    assert (m == m_expected).all()
+
+
+def test_token_aligner_project_to_empty_target_token_sequence():
+    source_tokens = ["abc", "def", "ghi", "jkl"]
+    target_tokens = []
+    ta = TokenAligner(source_tokens, target_tokens)
+    m = ta.project_tokens([1, 3])
+    m_expected = np.array([])
+    assert (m == m_expected).all()
+
+
+def test_token_aligner_project_to_mismatched_token_sequence():
+    source_tokens = ["abc", "def", "ghi", "jkl"]
+    target_tokens = ["qrs", "tuv", "wxy", "z"]
+    ta = TokenAligner(source_tokens, target_tokens)
+    m = ta.project_tokens([1])
+    m_expected = np.array([])
+    assert (m == m_expected).all()
+
+
+def test_token_aligner_project_span():
+    source_tokens = ["abc", "def", "ghi", "jkl"]
+    target_tokens = ["abc", "d", "ef", "ghi", "jkl"]
+    ta = TokenAligner(source_tokens, target_tokens)
+    m = ta.project_span(1, 2)
+    m_expected = np.array([1, 3])
+    assert (m == m_expected).all()
+
+
+def test_token_aligner_project_span_last_token_range_is_end_exclusive():
+    source_tokens = ["abc", "def", "ghi", "jkl"]
+    target_tokens = ["abc", "d", "ef", "ghi", "jkl"]
+    ta = TokenAligner(source_tokens, target_tokens)
+    m = ta.project_span(3, 4)
+    m_expected = np.array([4, 5])
+    assert (m == m_expected).all()
+
+
+def test_wpm_tok_idx_proj_1():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_token_index = [[0], [1], [2], [3], [4], [5], [6]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_wpm_tok_idx_proj_2():
+    src_tokens = ["I", "look", "at", "Sarah's", "dog.", "It", "was", "cute.!"]
+    tgt_tokens = ["I", "look", "at", "Sarah", "'", "s", "dog", ".", "It", "was", "cute", ".", "!"]
+    tgt_token_index = [[0], [1], [2], [3, 4, 5], [6, 7], [8], [9], [10, 11, 12]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_wpm_tok_idx_proj_3():
+    src_tokens = [
+        "Mr.",
+        "Immelt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "incomprehensibility",
+        "of",
+        "accounting",
+        "rules.",
+    ]
+    tgt_tokens = [
+        "Mr",
+        ".",
+        "I",
+        "##mme",
+        "##lt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "in",
+        "##com",
+        "##p",
+        "##re",
+        "##hen",
+        "##si",
+        "##bility",
+        "of",
+        "accounting",
+        "rules",
+        ".",
+    ]
+    tgt_token_index = [
+        [0, 1],
+        [2, 3, 4],
+        [5],
+        [6],
+        [7],
+        [8],
+        [9],
+        [10, 11, 12, 13, 14, 15, 16],
+        [17],
+        [18],
+        [19, 20],
+    ]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_wpm_tok_idx_proj_4():
+    src_tokens = ["What?"]
+    tgt_tokens = ["What", "?"]
+    tgt_token_index = [[0, 1]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_moses_tok_idx_proj_1():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_token_index = [[0], [1], [2], [3], [4], [5], [6]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_moses_tok_idx_proj_2():
+    src_tokens = ["I", "look", "at", "Sarah's", "dog.", "It", "was", "cute.!"]
+    tgt_tokens = ["I", "look", "at", "Sarah", "&apos;s", "dog", ".", "It", "was", "cute", ".", "!"]
+    tgt_token_index = [[0], [1], [2], [3, 4], [5, 6], [7], [8], [9, 10, 11]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_moses_tok_idx_proj_3():
+    src_tokens = [
+        "Mr.",
+        "Immelt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "incomprehensibility",
+        "of",
+        "accounting",
+        "rules.",
+    ]
+    tgt_tokens = [
+        "Mr.",
+        "Immelt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "incomprehensibility",
+        "of",
+        "accounting",
+        "rules",
+        ".",
+    ]
+    tgt_token_index = [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10, 11]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_moses_tok_idx_proj_4():
+    src_tokens = ["What?"]
+    tgt_tokens = ["What", "?"]
+    tgt_token_index = [[0, 1]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bpe_tok_idx_proj_1():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = [
+        "members</w>",
+        "of</w>",
+        "the</w>",
+        "house</w>",
+        "clapped</w>",
+        "their</w>",
+        "hands</w>",
+    ]
+    tgt_token_index = [[0], [1], [2], [3], [4], [5], [6]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bpe_tok_idx_proj_2():
+    src_tokens = ["I", "look", "at", "Sarah's", "dog.", "It", "was", "cute.!"]
+    tgt_tokens = [
+        "i</w>",
+        "look</w>",
+        "at</w>",
+        "sarah</w>",
+        "'s</w>",
+        "dog</w>",
+        ".</w>",
+        "it</w>",
+        "was</w>",
+        "cute</w>",
+        ".</w>",
+        "!</w>",
+    ]
+    tgt_token_index = [[0], [1], [2], [3, 4], [5, 6], [7], [8], [9, 10, 11]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bpe_tok_idx_proj_3():
+    src_tokens = [
+        "Mr.",
+        "Immelt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "incomprehensibility",
+        "of",
+        "accounting",
+        "rules.",
+    ]
+    tgt_tokens = [
+        "mr.</w>",
+        "im",
+        "melt</w>",
+        "chose</w>",
+        "to</w>",
+        "focus</w>",
+        "on</w>",
+        "the</w>",
+        "in",
+        "comprehen",
+        "si",
+        "bility</w>",
+        "of</w>",
+        "accounting</w>",
+        "rules</w>",
+        ".</w>",
+    ]
+    tgt_token_index = [[0], [1, 2], [3], [4], [5], [6], [7], [8, 9, 10, 11], [12], [13], [14, 15]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bpe_tok_idx_proj_4():
+    src_tokens = ["What?"]
+    tgt_tokens = ["what</w>", "?</w>"]
+    tgt_token_index = [[0, 1]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_sentencepiece_tok_idx_proj_1():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["▁Members", "▁of", "▁the", "▁House", "▁clapped", "▁their", "▁hands"]
+    tgt_token_index = [[0], [1], [2], [3], [4], [5], [6]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_sentencepiece_tok_idx_proj_2():
+    src_tokens = ["I", "look", "at", "Sarah's", "dog.", "It", "was", "cute.!"]
+    tgt_tokens = [
+        "▁I",
+        "▁look",
+        "▁at",
+        "▁Sarah",
+        "'",
+        "s",
+        "▁dog",
+        ".",
+        "▁It",
+        "▁was",
+        "▁cute",
+        ".",
+        "!",
+    ]
+    tgt_token_index = [[0], [1], [2], [3, 4, 5], [6, 7], [8], [9], [10, 11, 12]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_sentencepiece_tok_idx_proj_3():
+    src_tokens = [
+        "Mr.",
+        "Immelt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "incomprehensibility",
+        "of",
+        "accounting",
+        "rules.",
+    ]
+    tgt_tokens = [
+        "▁Mr",
+        ".",
+        "▁I",
+        "m",
+        "mel",
+        "t",
+        "▁chose",
+        "▁to",
+        "▁focus",
+        "▁on",
+        "▁the",
+        "▁in",
+        "comp",
+        "re",
+        "hen",
+        "s",
+        "ibility",
+        "▁of",
+        "▁accounting",
+        "▁rules",
+        ".",
+    ]
+    tgt_token_index = [
+        [0, 1],
+        [2, 3, 4, 5],
+        [6],
+        [7],
+        [8],
+        [9],
+        [10],
+        [11, 12, 13, 14, 15, 16],
+        [17],
+        [18],
+        [19, 20],
+    ]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_sentencepiece_tok_idx_proj_4():
+    src_tokens = ["What?"]
+    tgt_tokens = ["▁What", "?"]
+    tgt_token_index = [[0, 1]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bytebpe_tok_idx_proj_1():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "Ġof", "Ġthe", "ĠHouse", "Ġcl", "apped", "Ġtheir", "Ġhands"]
+    tgt_token_index = [[0], [1], [2], [3], [4, 5], [6], [7]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bytebpe_tok_idx_proj_2():
+    src_tokens = ["I", "look", "at", "Sarah's", "dog.", "It", "was", "cute.!"]
+    tgt_tokens = [
+        "I",
+        "Ġlook",
+        "Ġat",
+        "ĠSarah",
+        "'s",
+        "Ġdog",
+        ".",
+        "ĠIt",
+        "Ġwas",
+        "Ġcute",
+        ".",
+        "!",
+    ]
+    tgt_token_index = [[0], [1], [2], [3, 4], [5, 6], [7], [8], [9, 10, 11]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bytebpe_tok_idx_proj_3():
+    src_tokens = [
+        "Mr.",
+        "Immelt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "incomprehensibility",
+        "of",
+        "accounting",
+        "rules.",
+    ]
+    tgt_tokens = [
+        "Mr",
+        ".",
+        "ĠImm",
+        "elt",
+        "Ġchose",
+        "Ġto",
+        "Ġfocus",
+        "Ġon",
+        "Ġthe",
+        "Ġincomp",
+        "rehens",
+        "ibility",
+        "Ġof",
+        "Ġaccounting",
+        "Ġrules",
+        ".",
+    ]
+    tgt_token_index = [[0, 1], [2, 3], [4], [5], [6], [7], [8], [9, 10, 11], [12], [13], [14, 15]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+def test_bytebpe_tok_idx_proj_4():
+    src_tokens = ["What?"]
+    tgt_tokens = ["What", "?"]
+    tgt_token_index = [[0, 1]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    for src_token_idx in range(len(src_tokens)):
+        projected_tgt_tok_idx = ta.project_tokens(src_token_idx)
+        assert (tgt_token_index[src_token_idx] == projected_tgt_tok_idx).all()
+
+
+"""
+Note: test_project_span_* tests use same data and token aligner as test_bytebpe_tok_idx_proj_1. 
+Token projection is tested extensively above, the focus of the following tests is span projection. 
+For span prediction token token projection does the heavy lifting — tests covering span prediction 
+need to check that careful indexing.
+"""
+
+
+def test_project_span_single_token():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "Ġof", "Ġthe", "ĠHouse", "Ġcl", "apped", "Ġtheir", "Ġhands"]
+    # reference: tgt_token_index = [[0], [1], [2], [3], [4, 5], [6], [7]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    assert (0, 1) == ta.project_span(0, 1)
+
+
+def test_project_span_covering_multiple_source_sequence_tokens():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "Ġof", "Ġthe", "ĠHouse", "Ġcl", "apped", "Ġtheir", "Ġhands"]
+    # reference: tgt_token_index = [[0], [1], [2], [3], [4, 5], [6], [7]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    assert (0, 2) == ta.project_span(0, 2)
+
+
+def test_project_span_covering_multiple_target_sequence_tokens():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "Ġof", "Ġthe", "ĠHouse", "Ġcl", "apped", "Ġtheir", "Ġhands"]
+    # reference: tgt_token_index = [[0], [1], [2], [3], [4, 5], [6], [7]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    assert (4, 6) == ta.project_span(4, 5)
+
+
+def test_project_span_covering_whole_sequence():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "Ġof", "Ġthe", "ĠHouse", "Ġcl", "apped", "Ġtheir", "Ġhands"]
+    # reference: tgt_token_index = [[0], [1], [2], [3], [4, 5], [6], [7]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    assert (0, 8) == ta.project_span(0, 7)
+
+
+def test_project_invalid_span():
+    src_tokens = ["Members", "of", "the", "House", "clapped", "their", "hands"]
+    tgt_tokens = ["Members", "Ġof", "Ġthe", "ĠHouse", "Ġcl", "apped", "Ġtheir", "Ġhands"]
+    # reference: tgt_token_index = [[0], [1], [2], [3], [4, 5], [6], [7]]
+    ta = TokenAligner(src_tokens, tgt_tokens)
+    with pytest.raises(ValueError):
+        ta.project_span(0, 0)


### PR DESCRIPTION
This PR... 
- adds jiant1's sequence alignment functionality (7808e53), 
- strips out non-core functions (7468e54), 
- ports in and refactors test logic from jiant1 (dc07d85), 
- and updates the dependencies to include nltk and python-Levenshtein (96b18a1).

This PR does not port any of the additional logic associated with jiant1's [aligner_fn](https://github.com/nyu-mll/jiant/blob/d6faf55d79d38feba6666922ee62c082dc49ce2f/jiant/utils/retokenize.py#L385). A next PR will add that logic if it's necessary.

What kind of review would be helpful here? I would consider this logic pretty thoroughly reviewed already — this code was "battle tested" in jiant1, and while porting it over I reviewed it closely (and wrote docstrings).