### PR TITLE
Add some basic docs/tests for truncate_sequences

### DIFF
--- a/jiant/tasks/utils.py
+++ b/jiant/tasks/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import NamedTuple
+from typing import NamedTuple, Sequence
 
 
 class InclusiveSpan(NamedTuple):
@@ -31,7 +31,22 @@ class ExclusiveSpan(NamedTuple):
         return self
 
 
-def truncate_sequences(tokens_ls, max_length, truncate_end=True):
+def truncate_sequences(tokens_ls: Sequence[Sequence], max_length: int, truncate_end: bool = True):
+    """Takes a sequence of sequences and trims the sub-seqs to fit within the max length.
+
+    Trims the length of subsequences within a sequence until the total length of the combined sub-
+    sequences is within the max_length. While total length exceeds the max_length, trims whichever
+    subsequence is longest until the total combined length of the subsequences is under the limit.
+
+    Args:
+        tokens_ls (Sequence[Sequence]): sequence of subsequences to truncate.
+        max_length (int): the maximum length of the combined sub-sequences.
+        truncate_end (bool): if True, truncate from the end of the sub-sequence, else from start.
+
+    Returns:
+        Sequence[Sequence] with subsequences trimmed to fit within the max length when combined.
+
+    """
     if len(tokens_ls) == 0:
         return []
     if len(tokens_ls) == 1:

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,0 +1,37 @@
+from jiant.tasks.utils import truncate_sequences
+
+
+def test_truncate_empty_sequence():
+    seq = []
+    trunc_seq = truncate_sequences(seq, 10)
+    assert not trunc_seq
+
+
+def test_truncate_single_sequence_default_trunc_end():
+    seq = [["abc", "def", "ghi", "jkl", "mno", "pqr", "stu", "vwx", "yz"]]
+    trunc_seq = truncate_sequences(seq, 8)
+    assert trunc_seq == [["abc", "def", "ghi", "jkl", "mno", "pqr", "stu", "vwx"]]
+
+
+def test_truncate_single_sequence_trunc_start():
+    seq = [["abc", "def", "ghi", "jkl", "mno", "pqr", "stu", "vwx", "yz"]]
+    trunc_seq = truncate_sequences(seq, 8, False)
+    assert trunc_seq == [["def", "ghi", "jkl", "mno", "pqr", "stu", "vwx", "yz"]]
+
+
+def test_truncate_two_sequences_default_trunc_end():
+    seqs = [["abc", "def", "ghi", "jkl"], ["mno", "pqr", "stu", "vwx", "yz"]]
+    trunc_seqs = truncate_sequences(seqs, 8)
+    assert trunc_seqs == [["abc", "def", "ghi", "jkl"], ["mno", "pqr", "stu", "vwx"]]
+
+
+def test_truncate_more_than_two_sequences_trunc_start():
+    seqs = [["abc", "def", "ghi"], ["jkl", "mno", "pqr"], ["stu", "vwx", "yz"]]
+    trunc_seqs = truncate_sequences(seqs, 8)
+    assert trunc_seqs == [["abc", "def"], ["jkl", "mno", "pqr"], ["stu", "vwx", "yz"]]
+
+
+def test_truncate_two_sequences_default_trunc_start():
+    seqs = [["abc", "def", "ghi", "jkl"], ["mno", "pqr", "stu", "vwx", "yz"]]
+    trunc_seqs = truncate_sequences(seqs, 8, False)
+    assert trunc_seqs == [["abc", "def", "ghi", "jkl"], ["pqr", "stu", "vwx", "yz"]]


### PR DESCRIPTION
This PR adds some basic tests (and docstrings) for the `truncate_sequences` function.