### PR TITLE
Add pre-alignment tokenization normalization logic

### DIFF
--- a/jiant/utils/tokenization_normalization.py
+++ b/jiant/utils/tokenization_normalization.py
@@ -1,0 +1,122 @@
+"""Tokenization normalization (to improve likelihood of good cross tokenization alignment).
+
+This module provides helpers for normalizing space tokenization and target tokenizations to make
+proper alignment of the tokenizations more likely.
+
+Notes:
+    * Code is ported from https://github.com/nyu-mll/jiant/blob/master/jiant/utils/retokenize.py
+
+"""
+
+import re
+from typing import Sequence
+
+import transformers
+
+
+def normalize_tokenizations(
+    space_tokenization: Sequence[str],
+    target_tokenization: Sequence[str],
+    tokenizer: transformers.PreTrainedTokenizer,
+):
+    """Takes a space tokenization and a known target tokenization and normalizes them for alignment.
+
+    The purpose of this function is to normalize the space-tokenized sequence and target
+    tokenization to make proper alignment of the tokenizations more likely. This includes adding
+    beginning of word (BoW) or end of word (EoW) tags to the space tokenized and/or target
+    tokenization sequences. This also includes removing tokenizer-specific meta symbols, and
+    lower casing characters in the space tokenization to match target tokenizers (if uncased).
+
+    Warnings:
+        The normalized tokenizations produced by this function are not intended for use as inputs
+        to a model. These normalized tokenizations are only intended to be used to help find an
+        alignment between space tokenization and target tokenization.
+
+    Args:
+        space_tokenization (Seqence[str]): space-tokenized token sequence.
+        target_tokenization (Seqence[str]): target tokenizer tokenized sequence.
+        tokenizer (PreTrainedTokenizer): tokenizer carrying info needed for target normalization.
+
+    Returns:
+        Tuple(Sequence[str], Sequence[str]) of normalized space and target tokenizations.
+
+    Raises:
+        ValueError: if either space or target tokenization is an empty sequence.
+        ValueError: if tokenizer does not have a normalization strategy in this function.
+
+    """
+    if len(space_tokenization) == 0 or len(target_tokenization) == 0:
+        raise ValueError("Empty token sequence.")
+
+    if isinstance(tokenizer, transformers.BertTokenizer):
+        if tokenizer.init_kwargs.get("do_lower_case", False):
+            space_tokenization = [token.lower() for token in space_tokenization]
+        modifed_space_tokenization = bow_tag_tokens(space_tokenization)
+        modifed_target_tokenization = _process_wordpiece_tokens(target_tokenization)
+    elif isinstance(tokenizer, transformers.XLMTokenizer):
+        if tokenizer.init_kwargs.get("do_lowercase_and_remove_accent", False):
+            space_tokenization = [token.lower() for token in space_tokenization]
+        modifed_space_tokenization = eow_tag_tokens(space_tokenization)
+        modifed_target_tokenization = target_tokenization
+    elif isinstance(tokenizer, transformers.RobertaTokenizer):
+        modifed_space_tokenization = bow_tag_tokens(space_tokenization)
+        modifed_target_tokenization = ["Ġ" + target_tokenization[0]] + target_tokenization[1:]
+        modifed_target_tokenization = _process_bytebpe_tokens(modifed_target_tokenization)
+    elif isinstance(tokenizer, (transformers.AlbertTokenizer, transformers.XLMRobertaTokenizer)):
+        space_tokenization = [token.lower() for token in space_tokenization]
+        modifed_space_tokenization = bow_tag_tokens(space_tokenization)
+        modifed_target_tokenization = _process_sentencepiece_tokens(target_tokenization)
+    else:
+        raise ValueError("Tokenizer not supported.")
+
+    # safety check: if normalization changed sequence length, alignment is likely to break.
+    assert len(modifed_space_tokenization) == len(space_tokenization)
+    assert len(modifed_target_tokenization) == len(target_tokenization)
+
+    return modifed_space_tokenization, modifed_target_tokenization
+
+
+def bow_tag_tokens(tokens: Sequence[str], bow_tag: str = "<w>"):
+    """Applies a beginning of word (BoW) marker to every token in the tokens sequence."""
+    return [bow_tag + t for t in tokens]
+
+
+def eow_tag_tokens(tokens: Sequence[str], eow_tag: str = "</w>"):
+    """Applies a end of word (EoW) marker to every token in the tokens sequence."""
+    return [t + eow_tag for t in tokens]
+
+
+def _process_wordpiece_tokens(tokens: Sequence[str]):
+    return [_process_wordpiece_token_for_alignment(token) for token in tokens]
+
+
+def _process_sentencepiece_tokens(tokens: Sequence[str]):
+    return [_process_sentencepiece_token_for_alignment(token) for token in tokens]
+
+
+def _process_bytebpe_tokens(tokens: Sequence[str]):
+    return [_process_bytebpe_token_for_alignment(token) for token in tokens]
+
+
+def _process_wordpiece_token_for_alignment(t):
+    """Add word boundary markers, removes token prefix (no-space meta-symbol — '##' for BERT)."""
+    if t.startswith("##"):
+        return re.sub(r"^##", "", t)
+    else:
+        return "<w>" + t
+
+
+def _process_sentencepiece_token_for_alignment(t):
+    """Add word boundary markers, removes token prefix (space meta-symbol)."""
+    if t.startswith("▁"):
+        return "<w>" + re.sub(r"^▁", "", t)
+    else:
+        return t
+
+
+def _process_bytebpe_token_for_alignment(t):
+    """Add word boundary markers, removes token prefix (space meta-symbol)."""
+    if t.startswith("Ġ"):
+        return "<w>" + re.sub(r"^Ġ", "", t)
+    else:
+        return t

--- a/tests/utils/test_tokenization_normalization.py
+++ b/tests/utils/test_tokenization_normalization.py
@@ -1,0 +1,224 @@
+import pytest
+
+import jiant.utils.tokenization_normalization as tn
+
+from transformers import BertTokenizer, XLMTokenizer, RobertaTokenizer, AlbertTokenizer
+
+
+def test_process_wordpiece_token_sequence():
+    expected_adjusted_wordpiece_tokens = [
+        "<w>Mr",
+        "<w>.",
+        "<w>I",
+        "mme",
+        "lt",
+        "<w>chose",
+        "<w>to",
+        "<w>focus",
+        "<w>on",
+        "<w>the",
+        "<w>in",
+        "com",
+        "p",
+        "re",
+        "hen",
+        "si",
+        "bility",
+        "<w>of",
+        "<w>accounting",
+        "<w>rules",
+        "<w>.",
+    ]
+    original_wordpiece_tokens = [
+        "Mr",
+        ".",
+        "I",
+        "##mme",
+        "##lt",
+        "chose",
+        "to",
+        "focus",
+        "on",
+        "the",
+        "in",
+        "##com",
+        "##p",
+        "##re",
+        "##hen",
+        "##si",
+        "##bility",
+        "of",
+        "accounting",
+        "rules",
+        ".",
+    ]
+    adjusted_wordpiece_tokens = tn._process_wordpiece_tokens(original_wordpiece_tokens)
+    assert adjusted_wordpiece_tokens == expected_adjusted_wordpiece_tokens
+
+
+def test_process_sentencepiece_token_sequence():
+    expected_adjusted_sentencepiece_tokens = [
+        "<w>Mr",
+        ".",
+        "<w>I",
+        "m",
+        "mel",
+        "t",
+        "<w>chose",
+        "<w>to",
+        "<w>focus",
+        "<w>on",
+        "<w>the",
+        "<w>in",
+        "comp",
+        "re",
+        "hen",
+        "s",
+        "ibility",
+        "<w>of",
+        "<w>accounting",
+        "<w>rules",
+        ".",
+    ]
+    original_sentencepiece_tokens = [
+        "▁Mr",
+        ".",
+        "▁I",
+        "m",
+        "mel",
+        "t",
+        "▁chose",
+        "▁to",
+        "▁focus",
+        "▁on",
+        "▁the",
+        "▁in",
+        "comp",
+        "re",
+        "hen",
+        "s",
+        "ibility",
+        "▁of",
+        "▁accounting",
+        "▁rules",
+        ".",
+    ]
+    adjusted_sentencepiece_tokens = tn._process_sentencepiece_tokens(original_sentencepiece_tokens)
+    assert adjusted_sentencepiece_tokens == expected_adjusted_sentencepiece_tokens
+
+
+def test_process_bytebpe_token_sequence():
+    expected_adjusted_bytebpe_tokens = [
+        "Mr",
+        ".",
+        "<w>Imm",
+        "elt",
+        "<w>chose",
+        "<w>to",
+        "<w>focus",
+        "<w>on",
+        "<w>the",
+        "<w>incomp",
+        "rehens",
+        "ibility",
+        "<w>of",
+        "<w>accounting",
+        "<w>rules",
+        ".",
+    ]
+    original_bytebpe_tokens = [
+        "Mr",
+        ".",
+        "ĠImm",
+        "elt",
+        "Ġchose",
+        "Ġto",
+        "Ġfocus",
+        "Ġon",
+        "Ġthe",
+        "Ġincomp",
+        "rehens",
+        "ibility",
+        "Ġof",
+        "Ġaccounting",
+        "Ġrules",
+        ".",
+    ]
+    adjusted_bytebpe_tokens = tn._process_bytebpe_tokens(original_bytebpe_tokens)
+    assert adjusted_bytebpe_tokens == expected_adjusted_bytebpe_tokens
+
+
+"""
+The following tests are marked slow because they load/download real Transformers tokenizers.
+These tests will only be run with pytest flag --runslow. TODO: consider mocking tokenizers.
+"""
+
+
+@pytest.mark.slow
+def test_space_tokenization_and_bert_uncased_tokenization_normalization():
+    text = "Jeff Immelt chose to focus on the incomprehensibility of accounting rules ."
+    space_tokenized = text.split(" ")
+    tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+    target_tokenized = tokenizer.tokenize(text)
+    normed_space_tokenized, normed_target_tokenized = tn.normalize_tokenizations(
+        space_tokenized, target_tokenized, tokenizer
+    )
+    assert "".join(normed_space_tokenized) == "".join(normed_target_tokenized)
+
+
+@pytest.mark.slow
+def test_space_tokenization_and_bert_cased_tokenization_normalization():
+    text = "Jeff Immelt chose to focus on the incomprehensibility of accounting rules ."
+    space_tokenized = text.split(" ")
+    tokenizer = BertTokenizer.from_pretrained("bert-base-cased")
+    target_tokenized = tokenizer.tokenize(text)
+    normed_space_tokenized, normed_target_tokenized = tn.normalize_tokenizations(
+        space_tokenized, target_tokenized, tokenizer
+    )
+    assert "".join(normed_space_tokenized) == "".join(normed_target_tokenized)
+
+
+@pytest.mark.slow
+def test_space_tokenization_and_xlm_uncased_tokenization_normalization():
+    text = "Jeff Immelt chose to focus on the incomprehensibility of accounting rules ."
+    space_tokenized = text.split(" ")
+    tokenizer = XLMTokenizer.from_pretrained("xlm-mlm-en-2048")
+    target_tokenized = tokenizer.tokenize(text)
+    normed_space_tokenized, normed_target_tokenized = tn.normalize_tokenizations(
+        space_tokenized, target_tokenized, tokenizer
+    )
+    assert "".join(normed_space_tokenized) == "".join(normed_target_tokenized)
+
+
+@pytest.mark.slow
+def test_space_tokenization_and_roberta_tokenization_normalization():
+    text = "Jeff Immelt chose to focus on the incomprehensibility of accounting rules ."
+    space_tokenized = text.split(" ")
+    tokenizer = RobertaTokenizer.from_pretrained("roberta-base")
+    target_tokenized = tokenizer.tokenize(text)
+    normed_space_tokenized, normed_target_tokenized = tn.normalize_tokenizations(
+        space_tokenized, target_tokenized, tokenizer
+    )
+    assert "".join(normed_space_tokenized) == "".join(normed_target_tokenized)
+
+
+@pytest.mark.slow
+def test_space_tokenization_and_albert_tokenization_normalization():
+    text = "Jeff Immelt chose to focus on the incomprehensibility of accounting rules ."
+    space_tokenized = text.split(" ")
+    tokenizer = AlbertTokenizer.from_pretrained("albert-base-v1")
+    target_tokenized = tokenizer.tokenize(text)
+    normed_space_tokenized, normed_target_tokenized = tn.normalize_tokenizations(
+        space_tokenized, target_tokenized, tokenizer
+    )
+    assert "".join(normed_space_tokenized) == "".join(normed_target_tokenized)
+
+
+@pytest.mark.slow
+def test_normalize_empty_tokenizations():
+    text = ""
+    space_tokenized = text.split(" ")
+    tokenizer = AlbertTokenizer.from_pretrained("albert-base-v1")
+    target_tokenized = tokenizer.tokenize(text)
+    with pytest.raises(ValueError):
+        tn.normalize_tokenizations(space_tokenized, target_tokenized, tokenizer)

--- a/tests/utils/test_tokenization_normalization.py
+++ b/tests/utils/test_tokenization_normalization.py
@@ -222,3 +222,60 @@ def test_normalize_empty_tokenizations():
     target_tokenized = tokenizer.tokenize(text)
     with pytest.raises(ValueError):
         tn.normalize_tokenizations(space_tokenized, target_tokenized, tokenizer)
+
+
+@pytest.mark.slow
+def test_space_tokenization_and_unusual_roberta_tokenization_normalization():
+    text = (
+        "As a practitioner of ethnic humor from the old days on the Borscht Belt , live "
+        "television and the nightclub circuit , Mr. Mason instinctively reached for the "
+        "vernacular ."
+    )
+    space_tokenized = text.split(" ")
+    tokenizer = RobertaTokenizer.from_pretrained("roberta-base")
+    target_tokenized = tokenizer.tokenize(text)
+    # note 1: exposing the target tokenization to highlight an unusual tokenization:
+    # " vernacular" -> 'Ġ', 'vern', 'acular' (the usual pattern suggests 'Ġvern', 'acular')
+    assert target_tokenized == [
+        "As",
+        "Ġa",
+        "Ġpractitioner",
+        "Ġof",
+        "Ġethnic",
+        "Ġhumor",
+        "Ġfrom",
+        "Ġthe",
+        "Ġold",
+        "Ġdays",
+        "Ġon",
+        "Ġthe",
+        "ĠB",
+        "ors",
+        "cht",
+        "ĠBelt",
+        "Ġ,",
+        "Ġlive",
+        "Ġtelevision",
+        "Ġand",
+        "Ġthe",
+        "Ġnightclub",
+        "Ġcircuit",
+        "Ġ,",
+        "ĠMr",
+        ".",
+        "ĠMason",
+        "Ġinstinctively",
+        "Ġreached",
+        "Ġfor",
+        "Ġthe",
+        "Ġ",
+        "vern",
+        "acular",
+        "Ġ.",
+    ]
+    normed_space_tokenized, normed_target_tokenized = tn.normalize_tokenizations(
+        space_tokenized, target_tokenized, tokenizer
+    )
+    # note: 2: the assert below shows that even with the unusual tokenization (see note 1 above),
+    # after normalization the space tokenization and the target tokenization match.
+    assert "".join(normed_space_tokenized) == "".join(normed_target_tokenized)


### PR DESCRIPTION
This PR adds the (pre-alignment) tokenization normalization logic that was used in jiant1 (commit ac2698e). The module and `normalize_tokenizations` fn docstrings provide more information on the motivation/intent of these changes.

Please note that the following functions are taken directly from jiant1:
* `_process_wordpiece_token_for_alignment`
* `_process_sentencepiece_token_for_alignment`
* `_process_bytebpe_token_for_alignment`

Please note that new tests have been introduced to validate these changes, but some of these tests are marked with `@pytest.mark.slow` because they use real tokenizers (and are probably slower than we want to include in the unit tests that are run on every push to the repo). So, to run these tests include the `--runslow` flag in your pytest command.