### PR TITLE
Minor: re-order optimizer and scheduler steps

### DIFF
--- a/jiant/shared/model_setup.py
+++ b/jiant/shared/model_setup.py
@@ -46,9 +46,8 @@ class OptimizerScheduler:
         self.scheduler = scheduler
 
     def step(self):
-        # Scheduler updates first
-        self.scheduler.step()
         self.optimizer.step()
+        self.scheduler.step()
 
     def state_dict(self):
         return {


### PR DESCRIPTION
This PR swaps the order of optimizer and learning rate scheduler steps (addressing the warning pointed out by @HaokunLiu):

Warning message pre-change:
> UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`. Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate