### PR TITLE
Remove links to inactive docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,8 @@
 
 `jiant` is a software toolkit for natural language processing research, designed to facilitate work on multitask learning and transfer learning for sentence understanding tasks. 
 
-### Installation
-```
-git clone https://github.com/jiant-dev/jiant.git
-pip install -r jiant/requirements-dev.txt
-```
-
 ### Getting started
 Examples to help you get started can be found here [here](./examples/README.md).
-
-### Documentation
-Documentation for `jiant` v2.0.dev0 can be found [here](https://jiant-dev.github.io/jiant/).
 
 ### Issues
 Templates for bug reports and feature requests are provided [here](https://github.com/jiant-dev/jiant/issues/new/choose).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ html_theme_options = {
         ("Docs", "index", False, "home"),
         # ("ExternalLink", "http://example.com", True, 'launch'),
         # ("NoIconLink", "http://example.com", True, ''),
-        ("GitHub", "https://github.com/pyeres/jiant2", True, "link"),
+        ("GitHub", "https://github.com/jiant-dev/jiant", True, "link"),
     ],
     # Customize css colors.
     # For details see link.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,22 +5,5 @@
 
 .. role:: mono
 
-Documentation |release|
+Documentation |release| — coming soon!
 ==================================================
-
-:mono:`jiant` is a software toolkit for natural language processing research, designed to facilitate work on multitask learning and transfer learning for sentence understanding tasks. This documentation covers the core functionality of :mono:`jiant` v |release|.
-
-.. toctree::
-   :maxdepth: 2
-
-   getting-started
-   examples/index
-   modules/index
-
-
-.. Indices and tables
-.. ==================
-
-.. * :ref:`genindex`
-.. * :ref:`modindex`
-.. * :ref:`search`


### PR DESCRIPTION
This PR adds a "coming soon" message to the public docs page (and removes the link to those docs from the README).