### PR TITLE
Save example guids during write_preds

### DIFF
--- a/jiant/proj/main/components/evaluate.py
+++ b/jiant/proj/main/components/evaluate.py
@@ -29,7 +29,10 @@ def write_val_results(val_results_dict, metrics_aggregator, output_dir, verbose=
 
 
 def write_preds(eval_results_dict, path):
-    preds_dict = {
-        task_name: task_results["preds"] for task_name, task_results in eval_results_dict.items()
-    }
+    preds_dict = {}
+    for task_name, task_results_dict in eval_results_dict.items():
+        preds_dict[task_name] = {
+            "preds": task_results_dict["preds"],
+            "guids": task_results_dict["accumulator"].get_guids(),
+        }
     torch.save(preds_dict, path)

--- a/jiant/tasks/evaluate/core.py
+++ b/jiant/tasks/evaluate/core.py
@@ -62,9 +62,14 @@ class BaseEvaluationScheme:
 class ConcatenateLogitsAccumulator(BaseAccumulator):
     def __init__(self):
         self.logits_list = []
+        self.guid_list = []
 
     def update(self, batch_logits, batch_loss, batch, batch_metadata):
         self.logits_list.append(batch_logits)
+        self.guid_list.append(batch_metadata.get("guid"))
+
+    def get_guids(self):
+        return np.concatenate(self.guid_list)
 
     def get_accumulated(self):
         all_logits = np.concatenate(self.logits_list)


### PR DESCRIPTION
This PR is motivated by the need to save predictions with their associated identifiers. This PR...
* Modifies the pred accumulator to accumulate the guid associated with an example (0c7dbcd)
* Modifies `write_preds` to write the guids associated with the preds to file (32c41a0)

**How were these changes validated?**
These changes were validated by running a task (SST) with  `--write_val_preds` and `--write_test_preds` options, then inspecting the saved pred files (`val_preds.p` and `test_preds.p`), and confirming that the expected guids were present, e.g.:

```
{'sst': 
  {'preds': array([1, 1, 1, ..., 1, 1, 1]), 
   'guids': array(['test-0', 'test-1', ..., 'test-1820'], dtype='<U9')}  
}
```