### PR TITLE
Add direct data download support for WSC, MultiRC, and ReCoRD

### DIFF
--- a/jiant/scripts/download_data/constants.py
+++ b/jiant/scripts/download_data/constants.py
@@ -1,9 +1,8 @@
-# Some datasets in nlp are vastly different than the original dataset. We opt
-# to download the original dataset in this case.
+# Directly download tasks when nlp format is different than original dataset
 SQUAD_TASKS = {"squad_v1", "squad_v2"}
-INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS = {
+DIRECT_DOWNLOAD_TASKS_TO_DATA_URLS = {
     "wsc": f"https://dl.fbaipublicfiles.com/glue/superglue/data/v2/WSC.zip",
     "multirc": f"https://dl.fbaipublicfiles.com/glue/superglue/data/v2/MultiRC.zip",
     "record": f"https://dl.fbaipublicfiles.com/glue/superglue/data/v2/ReCoRD.zip",
 }
-INCOMPATIBLE_NLP_TASKS = INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS.keys()
+DIRECT_DOWNLOAD_TASKS = DIRECT_DOWNLOAD_TASKS_TO_DATA_URLS.keys()

--- a/jiant/scripts/download_data/constants.py
+++ b/jiant/scripts/download_data/constants.py
@@ -1,0 +1,9 @@
+# Some datasets in nlp are vastly different than the original dataset. We opt
+# to download the original dataset in this case.
+SQUAD_TASKS = {"squad_v1", "squad_v2"}
+INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS = {
+    "wsc": f"https://dl.fbaipublicfiles.com/glue/superglue/data/v2/WSC.zip",
+    "multirc": f"https://dl.fbaipublicfiles.com/glue/superglue/data/v2/MultiRC.zip",
+    "record": f"https://dl.fbaipublicfiles.com/glue/superglue/data/v2/ReCoRD.zip",
+}
+INCOMPATIBLE_NLP_TASKS = INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS.keys()

--- a/jiant/scripts/download_data/datasets/files_tasks.py
+++ b/jiant/scripts/download_data/datasets/files_tasks.py
@@ -7,6 +7,7 @@ import jiant.utils.python.io as py_io
 
 from jiant.scripts.download_data.constants import SQUAD_TASKS, INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS
 
+
 def download_squad_data_and_write_config(
     task_name: str, task_data_path: str, task_config_path: str
 ):
@@ -46,11 +47,13 @@ def download_task_data_and_write_config(task_name: str, task_data_path: str, tas
     assert task_name not in SQUAD_TASKS
 
     os.makedirs(task_data_path, exist_ok=True)
-    download_utils.download_and_unzip(INCOMPATIBLE_NLP_TASKS_TO_DATA_URL[task_name], task_data_path)
+    download_utils.download_and_unzip(
+        INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS[task_name], task_data_path
+    )
 
     # Move task data up one folder (nested under task name when unzipped)
     nested_task_dir = os.path.join(
-        task_data_path, filesystem.find_case_insensitve_filename(task_name, task_data_path)
+        task_data_path, filesystem.find_case_insensitive_filename(task_name, task_data_path)
     )
     task_data_files = os.listdir(nested_task_dir)
     for f in task_data_files:

--- a/jiant/scripts/download_data/datasets/files_tasks.py
+++ b/jiant/scripts/download_data/datasets/files_tasks.py
@@ -50,6 +50,7 @@ def download_task_data_and_write_config(task_name: str, task_data_path: str, tas
     download_utils.download_and_unzip(DIRECT_DOWNLOAD_TASKS_TO_DATA_URLS[task_name], task_data_path)
 
     # Move task data up one folder (nested under task name when unzipped)
+    # ie: mv ./record/ReCoRD/* ./record
     nested_task_dir = os.path.join(
         task_data_path, filesystem.find_case_insensitive_filename(task_name, task_data_path)
     )

--- a/jiant/scripts/download_data/datasets/files_tasks.py
+++ b/jiant/scripts/download_data/datasets/files_tasks.py
@@ -61,8 +61,16 @@ def download_task_data_and_write_config(task_name: str, task_data_path: str, tas
         shutil.move(os.path.join(nested_task_dir, f), os.path.join(task_data_path, f))
     shutil.rmtree(nested_task_dir)
 
+    # Supports datasets with non-standard dev dataset name
+    if os.path.isfile(os.path.join(task_data_path, "dev.jsonl")):
+        dev_data_name = "dev.jsonl"
+    elif os.path.isfile(os.path.join(task_data_path, "val.jsonl")):
+        dev_data_name = "val.jsonl"
+    else:
+        raise RuntimeError("Unsupported dev dataset name in downloaded task.")
+
+    val_path = os.path.join(task_data_path, dev_data_name)
     train_path = os.path.join(task_data_path, "train.jsonl")
-    val_path = os.path.join(task_data_path, "dev.jsonl")
     test_path = os.path.join(task_data_path, "test.jsonl")
     py_io.write_json(
         data={

--- a/jiant/scripts/download_data/datasets/files_tasks.py
+++ b/jiant/scripts/download_data/datasets/files_tasks.py
@@ -1,8 +1,11 @@
 import os
+import shutil
 
+import jiant.utils.python.filesystem as filesystem
 import jiant.scripts.download_data.utils as download_utils
 import jiant.utils.python.io as py_io
 
+from jiant.scripts.download_data.constants import SQUAD_TASKS, INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS
 
 def download_squad_data_and_write_config(
     task_name: str, task_data_path: str, task_config_path: str
@@ -33,6 +36,35 @@ def download_squad_data_and_write_config(
             "task": "squad",
             "paths": {"train": train_path, "val": val_path},
             "version_2_with_negative": version_2_with_negative,
+            "name": task_name,
+        },
+        path=task_config_path,
+    )
+
+
+def download_task_data_and_write_config(task_name: str, task_data_path: str, task_config_path: str):
+    assert task_name not in SQUAD_TASKS
+
+    os.makedirs(task_data_path, exist_ok=True)
+    download_utils.download_and_unzip(INCOMPATIBLE_NLP_TASKS_TO_DATA_URL[task_name], task_data_path)
+
+    # Move task data up one folder (nested under task name when unzipped)
+    nested_task_dir = os.path.join(
+        task_data_path, filesystem.find_case_insensitve_filename(task_name, task_data_path)
+    )
+    task_data_files = os.listdir(nested_task_dir)
+    for f in task_data_files:
+        # Overwrite file if it exists (overwrite by full path specification)
+        shutil.move(os.path.join(nested_task_dir, f), os.path.join(task_data_path, f))
+    shutil.rmtree(nested_task_dir)
+
+    train_path = os.path.join(task_data_path, "train.jsonl")
+    val_path = os.path.join(task_data_path, "dev.jsonl")
+    test_path = os.path.join(task_data_path, "test.jsonl")
+    py_io.write_json(
+        data={
+            "task": task_name,
+            "paths": {"train": train_path, "val": val_path, "test": test_path},
             "name": task_name,
         },
         path=task_config_path,

--- a/jiant/scripts/download_data/datasets/files_tasks.py
+++ b/jiant/scripts/download_data/datasets/files_tasks.py
@@ -5,7 +5,7 @@ import jiant.utils.python.filesystem as filesystem
 import jiant.scripts.download_data.utils as download_utils
 import jiant.utils.python.io as py_io
 
-from jiant.scripts.download_data.constants import SQUAD_TASKS, INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS
+from jiant.scripts.download_data.constants import SQUAD_TASKS, DIRECT_DOWNLOAD_TASKS_TO_DATA_URLS
 
 
 def download_squad_data_and_write_config(
@@ -47,9 +47,7 @@ def download_task_data_and_write_config(task_name: str, task_data_path: str, tas
     assert task_name not in SQUAD_TASKS
 
     os.makedirs(task_data_path, exist_ok=True)
-    download_utils.download_and_unzip(
-        INCOMPATIBLE_NLP_TASKS_TO_DATA_URLS[task_name], task_data_path
-    )
+    download_utils.download_and_unzip(DIRECT_DOWNLOAD_TASKS_TO_DATA_URLS[task_name], task_data_path)
 
     # Move task data up one folder (nested under task name when unzipped)
     nested_task_dir = os.path.join(

--- a/jiant/scripts/download_data/runscript.py
+++ b/jiant/scripts/download_data/runscript.py
@@ -6,9 +6,10 @@ import jiant.scripts.download_data.datasets.nlp_tasks as nlp_tasks_download
 import jiant.scripts.download_data.datasets.xtreme as xtreme_download
 import jiant.scripts.download_data.datasets.files_tasks as files_tasks_download
 from jiant.tasks.constants import GLUE_TASKS, SUPERGLUE_TASKS, XTREME_TASKS, BENCHMARKS
+from jiant.scripts.download_data.constants import SQUAD_TASKS, INCOMPATIBLE_NLP_TASKS
 
-NLP_DOWNLOADER_TASKS = GLUE_TASKS | SUPERGLUE_TASKS
-SUPPORTED_TASKS = NLP_DOWNLOADER_TASKS | XTREME_TASKS | {"squad_v1", "squad_v2"}
+NLP_DOWNLOADER_TASKS = GLUE_TASKS | SUPERGLUE_TASKS - INCOMPATIBLE_NLP_TASKS
+SUPPORTED_TASKS = NLP_DOWNLOADER_TASKS | XTREME_TASKS | SQUAD_TASKS | INCOMPATIBLE_NLP_TASKS
 
 
 # noinspection PyUnusedLocal
@@ -53,11 +54,17 @@ def download_data(task_names, output_base_path):
                 task_data_base_path=task_data_base_path,
                 task_config_base_path=task_config_base_path,
             )
-        elif task_name in ["squad_v1", "squad_v2"]:
+        elif task_name in SQUAD_TASKS:
             files_tasks_download.download_squad_data_and_write_config(
                 task_name=task_name,
                 task_data_path=task_data_path,
-                task_config_path=os.path.join(task_config_base_path, f"{task_name}.json"),
+                task_config_path=os.path.join(task_config_base_path, f"{task_name}_config.json"),
+            )
+        elif task_name in INCOMPATIBLE_NLP_TASKS:
+            files_tasks_download.download_task_data_and_write_config(
+                task_name=task_name,
+                task_data_path=task_data_path,
+                task_config_path=os.path.join(task_config_base_path, f"{task_name}_config.json"),
             )
         else:
             raise KeyError()

--- a/jiant/scripts/download_data/runscript.py
+++ b/jiant/scripts/download_data/runscript.py
@@ -6,10 +6,12 @@ import jiant.scripts.download_data.datasets.nlp_tasks as nlp_tasks_download
 import jiant.scripts.download_data.datasets.xtreme as xtreme_download
 import jiant.scripts.download_data.datasets.files_tasks as files_tasks_download
 from jiant.tasks.constants import GLUE_TASKS, SUPERGLUE_TASKS, XTREME_TASKS, BENCHMARKS
-from jiant.scripts.download_data.constants import SQUAD_TASKS, INCOMPATIBLE_NLP_TASKS
+from jiant.scripts.download_data.constants import SQUAD_TASKS, DIRECT_DOWNLOAD_TASKS
 
-NLP_DOWNLOADER_TASKS = GLUE_TASKS | SUPERGLUE_TASKS - INCOMPATIBLE_NLP_TASKS
-SUPPORTED_TASKS = NLP_DOWNLOADER_TASKS | XTREME_TASKS | SQUAD_TASKS | INCOMPATIBLE_NLP_TASKS
+# DIRECT_DOWNLOAD_TASKS need to be directly downloaded because the nlp
+# implementation differs from the original dataset format
+NLP_DOWNLOADER_TASKS = GLUE_TASKS | SUPERGLUE_TASKS - DIRECT_DOWNLOAD_TASKS
+SUPPORTED_TASKS = NLP_DOWNLOADER_TASKS | XTREME_TASKS | SQUAD_TASKS | DIRECT_DOWNLOAD_TASKS
 
 
 # noinspection PyUnusedLocal
@@ -60,7 +62,7 @@ def download_data(task_names, output_base_path):
                 task_data_path=task_data_path,
                 task_config_path=os.path.join(task_config_base_path, f"{task_name}_config.json"),
             )
-        elif task_name in INCOMPATIBLE_NLP_TASKS:
+        elif task_name in DIRECT_DOWNLOAD_TASKS:
             files_tasks_download.download_task_data_and_write_config(
                 task_name=task_name,
                 task_data_path=task_data_path,

--- a/jiant/utils/python/filesystem.py
+++ b/jiant/utils/python/filesystem.py
@@ -1,4 +1,7 @@
 import os
+import importlib
+import sys
+from contextlib import contextmanager
 
 
 def find_files(base_path, func):
@@ -47,3 +50,18 @@ def find_case_insensitive_filename(filename, path):
     for f in os.listdir(path):
         if f.lower() == filename.lower():
             return f
+
+
+@contextmanager
+def temporarily_add_sys_path(path):
+    sys.path = [path] + sys.path
+    yield
+    sys.path = sys.path[1:]
+
+
+def import_from_path(path):
+    base_path, filename = os.path.split(path)
+    module_name = filename[:-3] if filename.endswith(".py") else filename
+    with temporarily_add_sys_path(base_path):
+        module = importlib.import_module(module_name)
+    return module

--- a/jiant/utils/python/filesystem.py
+++ b/jiant/utils/python/filesystem.py
@@ -1,7 +1,4 @@
 import os
-import importlib
-import sys
-from contextlib import contextmanager
 
 
 def find_files(base_path, func):
@@ -46,16 +43,7 @@ def get_code_asset_path(*rel_path):
     return os.path.join(get_code_base_path(), *rel_path)
 
 
-@contextmanager
-def temporarily_add_sys_path(path):
-    sys.path = [path] + sys.path
-    yield
-    sys.path = sys.path[1:]
-
-
-def import_from_path(path):
-    base_path, filename = os.path.split(path)
-    module_name = filename[:-3] if filename.endswith(".py") else filename
-    with temporarily_add_sys_path(base_path):
-        module = importlib.import_module(module_name)
-    return module
+def find_case_insensitive_filename(filename, path):
+    for f in os.listdir(path):
+        if f.lower() == filename.lower():
+            return f


### PR DESCRIPTION
Some tasks in [`nlp`](https://github.com/huggingface/nlp) are in stored in a different format than the original dataset. In these cases, we download the dataset directly and bypass the `nlp` downloader. For SuperGLUE tasks, it is necessary to directly download the datasets for WSC, MultiRC, and ReCORD. Currently, `tokenize_and_cache.py` fails for these tasks. In the future, it may be desirable to support `nlp` examples directly.

**How were these changes validated?**
All SuperGLUE data was downloaded and configs were generated using the following command:
`python jiant/scripts/download_data/runscript.py download --benchmark SUPERGLUE --output_path $WORKING_DIR/data`
The outputs were inspected manually.