### PR TITLE
Fix WiC tokenization using adjacency matrix alignment utility

### DIFF
--- a/jiant/tasks/lib/wic.py
+++ b/jiant/tasks/lib/wic.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 from dataclasses import dataclass
 from typing import List
+import string
 
 from jiant.tasks.core import (
     BaseExample,
@@ -18,7 +19,8 @@ from jiant.tasks.lib.templates.shared import (
 )
 from jiant.tasks.utils import truncate_sequences, ExclusiveSpan
 from jiant.utils.python.io import read_json_lines
-from jiant.tasks.lib.templates import hacky_tokenization_matching as tokenization_utils
+from jiant.utils import retokenize
+from jiant.utils.tokenization_normalization import normalize_tokenizations
 
 
 @dataclass
@@ -32,20 +34,61 @@ class Example(BaseExample):
     label: str
 
     def tokenize(self, tokenizer):
-        sentence1_tokens, sentence1_span = tokenization_utils.get_token_span(
-            sentence=self.sentence1, span=self.span1, tokenizer=tokenizer,
+        def tokenize_span(tokenizer, sentence: str, char_span: ExclusiveSpan):
+            """Tokenizes sentence and projects char_span to token span.
+
+            Args:
+                tokenizer (transformers.PreTrainedTokenizer): Tokenizer used
+                sentence (str): Sentence to be tokenized
+                char_span (ExclusiveSpan): character indexed span for sentence
+
+            Returns:
+                sentence_target_tokenization (List[str]): tokenized sentence
+                target_span (ExclusiveSpane): token span for sentence
+            """
+            span_start_idx = len(sentence[: char_span.start].split())
+            # If the first word in a span starts with punctuation, the first word will
+            # erroneously be split into two strings by .split().
+            # ie: 'takeaway' -> ["'", "takeaway"]
+            # For span alignment, we start the list index at the punctuation.
+            if (span_start_idx != 0) and (sentence[: (char_span.start)][-1] in string.punctuation):
+                span_start_idx = span_start_idx - 1
+            span_text = sentence[char_span.start : char_span.end]
+
+            sentence_space_tokenization = sentence.split()
+            sentence_target_tokenization = tokenizer.tokenize(sentence)
+            (
+                sentence_normed_space_tokenization,
+                sentence_normed_target_tokenization,
+            ) = normalize_tokenizations(
+                sentence_space_tokenization, sentence_target_tokenization, tokenizer
+            )
+            span_start_char = len(" ".join(sentence_normed_space_tokenization[:span_start_idx]))
+            span_text_char = len(span_text)
+            aligner = retokenize.TokenAligner(
+                sentence_normed_space_tokenization, sentence_normed_target_tokenization
+            )
+            target_span = ExclusiveSpan(
+                *aligner.project_char_to_token_span(
+                    span_start_char, span_start_char + span_text_char
+                )
+            )
+            return sentence_target_tokenization, target_span
+
+        sentence1_target_tokenization, target_span1 = tokenize_span(
+            tokenizer, self.sentence1, self.span1
         )
-        sentence2_tokens, sentence2_span = tokenization_utils.get_token_span(
-            sentence=self.sentence2, span=self.span2, tokenizer=tokenizer,
+        sentence2_target_tokenization, target_span2 = tokenize_span(
+            tokenizer, self.sentence2, self.span2
         )
 
         return TokenizedExample(
             guid=self.guid,
-            sentence1_tokens=sentence1_tokens,
-            sentence2_tokens=sentence2_tokens,
+            sentence1_tokens=sentence1_target_tokenization,
+            sentence2_tokens=sentence2_target_tokenization,
             word=tokenizer.tokenize(self.word),  # might be more than one token
-            sentence1_span=sentence1_span,
-            sentence2_span=sentence2_span,
+            sentence1_span=target_span1,
+            sentence2_span=target_span2,
             label_id=WiCTask.LABEL_TO_ID[self.label],
         )
 

--- a/jiant/utils/testing/utils.py
+++ b/jiant/utils/testing/utils.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def is_pytest():
+    return "pytest" in sys.modules

--- a/jiant/utils/tokenization_normalization.py
+++ b/jiant/utils/tokenization_normalization.py
@@ -9,9 +9,10 @@ Notes:
 """
 
 import re
+import transformers
 from typing import Sequence
 
-import transformers
+from jiant.utils.testing import utils as test_utils
 
 
 def normalize_tokenizations(
@@ -67,9 +68,7 @@ def normalize_tokenizations(
         modifed_space_tokenization = bow_tag_tokens(space_tokenization)
         modifed_target_tokenization = _process_sentencepiece_tokens(target_tokenization)
     else:
-        import sys
-
-        if "pytest" in sys.modules:
+        if test_utils.is_pytest():
             from jiant.utils.testing.tokenizer import SimpleSpaceTokenizer
 
             if isinstance(tokenizer, SimpleSpaceTokenizer):

--- a/jiant/utils/tokenization_normalization.py
+++ b/jiant/utils/tokenization_normalization.py
@@ -67,6 +67,13 @@ def normalize_tokenizations(
         modifed_space_tokenization = bow_tag_tokens(space_tokenization)
         modifed_target_tokenization = _process_sentencepiece_tokens(target_tokenization)
     else:
+        import sys
+
+        if "pytest" in sys.modules:
+            from jiant.utils.testing.tokenizer import SimpleSpaceTokenizer
+
+            if isinstance(tokenizer, SimpleSpaceTokenizer):
+                return space_tokenization, target_tokenization
         raise ValueError("Tokenizer not supported.")
 
     # safety check: if normalization changed sequence length, alignment is likely to break.

--- a/tests/tasks/lib/test_wic.py
+++ b/tests/tasks/lib/test_wic.py
@@ -1,0 +1,70 @@
+from collections import Counter
+
+from jiant.tasks.utils import ExclusiveSpan
+from jiant.tasks.lib.wic import Example, TokenizedExample
+from jiant.utils.testing.tokenizer import SimpleSpaceTokenizer
+
+
+EXAMPLES = [
+    Example(
+        guid="train-1",
+        sentence1="Approach a task.",
+        sentence2="To approach the city.",
+        word="approach",
+        span1=ExclusiveSpan(start=0, end=8),
+        span2=ExclusiveSpan(start=3, end=11),
+        label=False,
+    ),
+    Example(
+        guid="train-2",
+        sentence1="In England they call takeout food 'takeaway'.",
+        sentence2="If you're hungry, there's a takeaway just around the corner.",
+        word="takeaway",
+        span1=ExclusiveSpan(start=35, end=43),
+        span2=ExclusiveSpan(start=28, end=36),
+        label=True,
+    ),
+]
+
+TOKENIZED_EXAMPLES = [
+    TokenizedExample(
+        guid="train-1",
+        sentence1_tokens=["Approach", "a", "task."],
+        sentence2_tokens=["To", "approach", "the", "city."],
+        word=["approach"],
+        sentence1_span=ExclusiveSpan(start=0, end=1),
+        sentence2_span=ExclusiveSpan(start=1, end=2),
+        label_id=0,
+    ),
+    TokenizedExample(
+        guid="train-2",
+        sentence1_tokens=["In", "England", "they", "call", "takeout", "food", "'takeaway'."],
+        sentence2_tokens=[
+            "If",
+            "you're",
+            "hungry,",
+            "there's",
+            "a",
+            "takeaway",
+            "just",
+            "around",
+            "the",
+            "corner.",
+        ],
+        word=["takeaway"],
+        sentence1_span=ExclusiveSpan(start=6, end=7),
+        sentence2_span=ExclusiveSpan(start=5, end=6),
+        label_id=1,
+    ),
+]
+
+
+def test_task_tokenization():
+    token_counter = Counter()
+    for example in EXAMPLES:
+        token_counter.update(example.sentence1.split() + example.sentence2.split())
+    token_vocab = list(token_counter.keys())
+    tokenizer = SimpleSpaceTokenizer(vocabulary=token_vocab)
+
+    for example, tokenized_example in zip(EXAMPLES, TOKENIZED_EXAMPLES):
+        assert example.tokenize(tokenizer).to_dict() == tokenized_example.to_dict()


### PR DESCRIPTION
This PR closes #140 and adds tokenization tests for the failing WiC examples. Span alignment was switched from `hacky_tokenization` to the `retokenize` utility.

**How were these changes validated?**
`tokenize_and_cache.py` was run with previously failing examples and manually checked for veracity. Test cases were added for WiC tokenization.