### PR TITLE
Output proj/main/runscript.py RunConfiguration object to file

### DIFF
--- a/jiant/proj/main/runscript.py
+++ b/jiant/proj/main/runscript.py
@@ -211,7 +211,7 @@ def run_loop(args: RunConfiguration, checkpoint=None):
     ):
         os.remove(os.path.join(args.output_dir, "checkpoint.p"))
 
-    py_io.write_file(args.to_json(), os.path.join(args.output_dir, "run_config.json"))
+    py_io.write_file(args.to_json(), os.path.join(args.output_dir, "run_main_config.json"))
     py_io.write_file("DONE", os.path.join(args.output_dir, "done_file"))
 
 

--- a/jiant/proj/main/runscript.py
+++ b/jiant/proj/main/runscript.py
@@ -211,6 +211,7 @@ def run_loop(args: RunConfiguration, checkpoint=None):
     ):
         os.remove(os.path.join(args.output_dir, "checkpoint.p"))
 
+    py_io.write_file(args.to_json(), os.path.join(args.output_dir, "run_config.json"))
     py_io.write_file("DONE", os.path.join(args.output_dir, "done_file"))
 
 


### PR DESCRIPTION
This PR improves result reproducibility by writing the RunConfiguration object used to run the jiant experiment to `run_config.json`. This is an incremental step towards reproducibility since there are currently 3 main objects to reproduce `jiant` results (run configuration, jiant task container, and task data configuration).