### PR TITLE
MLM Pre-masked

### DIFF
--- a/jiant/tasks/evaluate/core.py
+++ b/jiant/tasks/evaluate/core.py
@@ -153,7 +153,9 @@ class MLMPremaskedAccumulator(BaseAccumulator):
     def update(self, batch_logits, batch_loss, batch, batch_metadata):
         batch_size = len(batch)
         # Select the tokens that we do MLM prediction on
-        masked_tokens_selector = batch.masked_lm_labels.cpu().numpy() != mlm_template.NON_MASKED_TOKEN_LABEL_ID
+        masked_tokens_selector = (
+            batch.masked_lm_labels.cpu().numpy() != mlm_template.NON_MASKED_TOKEN_LABEL_ID
+        )
         for i in range(batch_size):
             # noinspection PyUnresolvedReferences
             self.logits_list.append(batch_logits[i][masked_tokens_selector[i]])

--- a/jiant/tasks/evaluate/core.py
+++ b/jiant/tasks/evaluate/core.py
@@ -17,6 +17,7 @@ import jiant.tasks.lib.templates.squad_style.utils as squad_style_utils
 import jiant.tasks.lib.mlqa as mlqa_lib
 import jiant.tasks.lib.bucc2018 as bucc2018_lib
 import jiant.tasks.lib.tatoeba as tatoeba_lib
+from jiant.tasks.lib.templates import mlm as mlm_template
 from jiant.utils.python.datastructures import ExtendedDataClassMixin
 from jiant.utils.python.io import read_json
 from jiant.utils.string_comparing import string_f1_score, exact_match_score
@@ -33,8 +34,12 @@ class BaseEvaluation:
 
 
 class BaseAccumulator:
+
     def update(self, batch_logits, batch_loss, batch, batch_metadata):
         raise NotImplementedError()
+
+    def get_guids(self):
+        return None
 
     def get_accumulated(self):
         raise NotImplementedError()
@@ -139,6 +144,21 @@ class SpanPredictionF1andEMScheme(BaseEvaluationScheme):
     ) -> Metrics:
         preds = self.get_preds_from_accumulator(task=task, accumulator=accumulator)
         return self.compute_metrics_from_preds_and_labels(preds=preds, labels=labels)
+
+
+class MLMPremaskedAccumulator(BaseAccumulator):
+    def __init__(self):
+        self.logits_list = []
+
+    def update(self, batch_logits, batch_loss, batch, batch_metadata):
+        batch_size = len(batch)
+        non_masked = batch.masked_lm_labels.cpu().numpy() != mlm_template.NON_MASKED_TOKEN_LABEL_ID
+        for i in range(batch_size):
+            # noinspection PyUnresolvedReferences
+            self.logits_list.append(batch_logits[i][non_masked[i]])
+
+    def get_accumulated(self):
+        return self.logits_list
 
 
 class TatoebaAccumulator(BaseAccumulator):
@@ -727,6 +747,37 @@ class MLMEvaluationScheme(BaseEvaluationScheme):
         )
 
 
+class MLMPremaskedEvaluationScheme(MLMEvaluationScheme):
+    @classmethod
+    def get_accumulator(cls) -> BaseAccumulator:
+        return MLMPremaskedAccumulator()
+
+    @classmethod
+    def get_labels_from_cache_and_examples(cls, task, cache, examples):
+        labels = []
+        for datum in cache.iter_all():
+            masked_lm_labels = datum["data_row"].masked_lm_labels
+            labels.append(
+                masked_lm_labels[masked_lm_labels != mlm_template.NON_MASKED_TOKEN_LABEL_ID]
+            )
+        return labels
+
+    def get_preds_from_accumulator(self, task, accumulator):
+        return accumulator.get_accumulated()
+
+    def compute_metrics_from_accumulator(
+        self, task, accumulator: BaseAccumulator, tokenizer, labels
+    ) -> Metrics:
+        loss_list = accumulator.get_accumulated()
+        average_loss = mean(loss_list)
+        perplexity = np.exp(average_loss)
+        return Metrics(
+            # Major = negative perplexity
+            major=-perplexity,
+            minor={"perplexity": perplexity},
+        )
+
+
 class TatoebaEvaluationScheme(BaseEvaluationScheme):
     def get_accumulator(self):
         return TatoebaAccumulator()
@@ -887,6 +938,8 @@ def get_evaluation_scheme_for_task(task) -> BaseEvaluationScheme:
         return PearsonAndSpearmanEvaluationScheme()
     elif isinstance(task, tasks.MLMSimpleTask):
         return MLMEvaluationScheme()
+    elif isinstance(task, (tasks.MLMPremaskedTask, tasks.MLMPretokenizedTask)):
+        return MLMPremaskedEvaluationScheme()
     elif isinstance(task, (tasks.QAMRTask, tasks.QASRLTask)):
         return SpanPredictionF1andEMScheme()
     elif isinstance(task, (tasks.UdposTask, tasks.PanxTask)):

--- a/jiant/tasks/evaluate/core.py
+++ b/jiant/tasks/evaluate/core.py
@@ -34,7 +34,6 @@ class BaseEvaluation:
 
 
 class BaseAccumulator:
-
     def update(self, batch_logits, batch_loss, batch, batch_metadata):
         raise NotImplementedError()
 

--- a/jiant/tasks/lib/mlm_premasked.py
+++ b/jiant/tasks/lib/mlm_premasked.py
@@ -1,24 +1,14 @@
-import numpy as np
-import torch
 from dataclasses import dataclass
 from typing import List
 
 import jiant.utils.python.io as py_io
-from jiant.tasks.lib.templates import mlm as mlm_template
 from jiant.tasks.core import (
     Task,
     TaskTypes,
     BaseExample,
-    BaseTokenizedExample,
-    BaseDataRow,
-    BatchMixin,
 )
-from jiant.tasks.utils import ExclusiveSpan, truncate_sequences
-from jiant.tasks.lib.templates.shared import (
-    construct_single_input_tokens_and_segment_ids,
-    create_input_set_from_tokens_and_segments,
-    pad_single_with_feat_spec,
-)
+from jiant.tasks.utils import ExclusiveSpan
+import jiant.tasks.lib.templates.mlm_premasked as mlm_premasked_template
 
 
 @dataclass
@@ -58,75 +48,18 @@ class Example(BaseExample):
 
 
 @dataclass
-class TokenizedExample(BaseTokenizedExample):
-    guid: str
-    masked_tokens: List
-    label_tokens: List
-
-    def featurize(self, tokenizer, feat_spec):
-        # Handle masked_tokens
-        unpadded_masked_inputs = construct_single_input_tokens_and_segment_ids(
-            input_tokens=self.masked_tokens, tokenizer=tokenizer, feat_spec=feat_spec,
-        )
-        masked_input_set = create_input_set_from_tokens_and_segments(
-            unpadded_tokens=unpadded_masked_inputs.unpadded_tokens,
-            unpadded_segment_ids=unpadded_masked_inputs.unpadded_segment_ids,
-            tokenizer=tokenizer,
-            feat_spec=feat_spec,
-        )
-        # Handle label_tokens
-        special_tokens_count = 2  # CLS, SEP
-        pad_token = tokenizer.pad_token
-        unpadded_label_tokens, = truncate_sequences(
-            tokens_ls=[self.label_tokens],
-            max_length=feat_spec.max_seq_length - special_tokens_count,
-        )
-        if feat_spec.cls_token_at_end:
-            unpadded_label_tokens = unpadded_label_tokens + [pad_token, pad_token]
-        else:
-            unpadded_label_tokens = [pad_token] + unpadded_label_tokens + [pad_token]
-        unpadded_label_token_ids = tokenizer.convert_tokens_to_ids(unpadded_label_tokens)
-        masked_lm_labels = pad_single_with_feat_spec(
-            ls=unpadded_label_token_ids, feat_spec=feat_spec, pad_idx=feat_spec.pad_token_id,
-        )
-        masked_lm_labels = np.array(masked_lm_labels)
-        masked_lm_labels[masked_lm_labels == feat_spec.pad_token_id] = \
-            mlm_template.NON_MASKED_TOKEN_LABEL_ID
-        return DataRow(
-            guid=self.guid,
-            masked_input_ids=np.array(masked_input_set.input_ids),
-            input_mask=np.array(masked_input_set.input_mask),
-            segment_ids=np.array(masked_input_set.segment_ids),
-            masked_lm_labels=masked_lm_labels,
-            masked_tokens=unpadded_masked_inputs.unpadded_tokens,
-            label_tokens=unpadded_label_tokens,
-        )
+class TokenizedExample(mlm_premasked_template.TokenizedExample):
+    pass
 
 
 @dataclass
-class DataRow(BaseDataRow):
-    guid: str
-    masked_input_ids: np.ndarray
-    input_mask: np.ndarray
-    segment_ids: np.ndarray
-    masked_lm_labels: np.ndarray
-    masked_tokens: List
-    label_tokens: List
+class DataRow(mlm_premasked_template.BaseDataRow):
+    pass
 
 
 @dataclass
-class Batch(BatchMixin, mlm_template.BaseMLMBatch):
-    masked_input_ids: torch.LongTensor
-    input_mask: torch.LongTensor
-    segment_ids: torch.LongTensor
-    masked_lm_labels: torch.LongTensor
-    masked_tokens: List
-    label_tokens: List
-
-    def get_masked(self, mlm_probability, tokenizer, do_mask):
-        assert mlm_probability is None
-        assert not do_mask
-        return self
+class Batch(mlm_premasked_template.Batch):
+    pass
 
 
 class MLMPremaskedTask(Task):

--- a/jiant/tasks/lib/mlm_premasked.py
+++ b/jiant/tasks/lib/mlm_premasked.py
@@ -41,9 +41,7 @@ class Example(BaseExample):
             label_tokens += [tokenizer.pad_token] * len(tokenized_text)
 
         return TokenizedExample(
-            guid=self.guid,
-            masked_tokens=masked_tokens,
-            label_tokens=label_tokens,
+            guid=self.guid, masked_tokens=masked_tokens, label_tokens=label_tokens,
         )
 
 

--- a/jiant/tasks/lib/mlm_premasked.py
+++ b/jiant/tasks/lib/mlm_premasked.py
@@ -62,7 +62,7 @@ class Batch(mlm_premasked_template.Batch):
 
 class MLMPremaskedTask(Task):
     Example = Example
-    TokenizedExample = Example
+    TokenizedExample = TokenizedExample
     DataRow = DataRow
     Batch = Batch
 

--- a/jiant/tasks/lib/mlm_premasked.py
+++ b/jiant/tasks/lib/mlm_premasked.py
@@ -1,0 +1,161 @@
+import numpy as np
+import torch
+from dataclasses import dataclass
+from typing import List
+
+import jiant.utils.python.io as py_io
+from jiant.tasks.lib.templates import mlm as mlm_template
+from jiant.tasks.core import (
+    Task,
+    TaskTypes,
+    BaseExample,
+    BaseTokenizedExample,
+    BaseDataRow,
+    BatchMixin,
+)
+from jiant.tasks.utils import ExclusiveSpan, truncate_sequences
+from jiant.tasks.lib.templates.shared import (
+    construct_single_input_tokens_and_segment_ids,
+    create_input_set_from_tokens_and_segments,
+    pad_single_with_feat_spec,
+)
+
+
+@dataclass
+class Example(BaseExample):
+    guid: str
+    text: str
+    # Spans over char indices
+    masked_spans: List[ExclusiveSpan]
+
+    def tokenize(self, tokenizer):
+        # masked_tokens will be regular tokens except with tokenizer.mask_token for masked spans
+        # label_tokens will be tokenizer.pad_token except with the regular tokens for masked spans
+        masked_tokens = []
+        label_tokens = []
+        curr = 0
+        for start, end in self.masked_spans:
+            # Handle text before next mask
+            tokenized_text = tokenizer.tokenize(self.text[curr:start])
+            masked_tokens += tokenized_text
+            label_tokens += [tokenizer.pad_token] * len(tokenized_text)
+
+            # Handle mask
+            tokenized_masked_text = tokenizer.tokenize(self.text[start:end])
+            masked_tokens += [tokenizer.mask_token] * len(tokenized_masked_text)
+            label_tokens += tokenized_masked_text
+            curr = end
+        if curr < len(self.text):
+            tokenized_text = tokenizer.tokenize(self.text[curr:])
+            masked_tokens += tokenized_text
+            label_tokens += [tokenizer.pad_token] * len(tokenized_text)
+
+        return TokenizedExample(
+            guid=self.guid,
+            masked_tokens=masked_tokens,
+            label_tokens=label_tokens,
+        )
+
+
+@dataclass
+class TokenizedExample(BaseTokenizedExample):
+    guid: str
+    masked_tokens: List
+    label_tokens: List
+
+    def featurize(self, tokenizer, feat_spec):
+        # Handle masked_tokens
+        unpadded_masked_inputs = construct_single_input_tokens_and_segment_ids(
+            input_tokens=self.masked_tokens, tokenizer=tokenizer, feat_spec=feat_spec,
+        )
+        masked_input_set = create_input_set_from_tokens_and_segments(
+            unpadded_tokens=unpadded_masked_inputs.unpadded_tokens,
+            unpadded_segment_ids=unpadded_masked_inputs.unpadded_segment_ids,
+            tokenizer=tokenizer,
+            feat_spec=feat_spec,
+        )
+        # Handle label_tokens
+        special_tokens_count = 2  # CLS, SEP
+        pad_token = tokenizer.pad_token
+        unpadded_label_tokens, = truncate_sequences(
+            tokens_ls=[self.label_tokens],
+            max_length=feat_spec.max_seq_length - special_tokens_count,
+        )
+        if feat_spec.cls_token_at_end:
+            unpadded_label_tokens = unpadded_label_tokens + [pad_token, pad_token]
+        else:
+            unpadded_label_tokens = [pad_token] + unpadded_label_tokens + [pad_token]
+        unpadded_label_token_ids = tokenizer.convert_tokens_to_ids(unpadded_label_tokens)
+        masked_lm_labels = pad_single_with_feat_spec(
+            ls=unpadded_label_token_ids, feat_spec=feat_spec, pad_idx=feat_spec.pad_token_id,
+        )
+        masked_lm_labels = np.array(masked_lm_labels)
+        masked_lm_labels[masked_lm_labels == feat_spec.pad_token_id] = \
+            mlm_template.NON_MASKED_TOKEN_LABEL_ID
+        return DataRow(
+            guid=self.guid,
+            masked_input_ids=np.array(masked_input_set.input_ids),
+            input_mask=np.array(masked_input_set.input_mask),
+            segment_ids=np.array(masked_input_set.segment_ids),
+            masked_lm_labels=masked_lm_labels,
+            masked_tokens=unpadded_masked_inputs.unpadded_tokens,
+            label_tokens=unpadded_label_tokens,
+        )
+
+
+@dataclass
+class DataRow(BaseDataRow):
+    guid: str
+    masked_input_ids: np.ndarray
+    input_mask: np.ndarray
+    segment_ids: np.ndarray
+    masked_lm_labels: np.ndarray
+    masked_tokens: List
+    label_tokens: List
+
+
+@dataclass
+class Batch(BatchMixin, mlm_template.BaseMLMBatch):
+    masked_input_ids: torch.LongTensor
+    input_mask: torch.LongTensor
+    segment_ids: torch.LongTensor
+    masked_lm_labels: torch.LongTensor
+    masked_tokens: List
+    label_tokens: List
+
+    def get_masked(self, mlm_probability, tokenizer, do_mask):
+        assert mlm_probability is None
+        assert not do_mask
+        return self
+
+
+class MLMPremaskedTask(Task):
+    Example = Example
+    TokenizedExample = Example
+    DataRow = DataRow
+    Batch = Batch
+
+    TASK_TYPE = TaskTypes.MASKED_LANGUAGE_MODELING
+
+    def __init__(self, name, path_dict):
+        super().__init__(name=name, path_dict=path_dict)
+        self.mlm_probability = None
+        self.do_mask = False
+
+    def get_train_examples(self):
+        return self._create_examples(path=self.train_path, set_type="train")
+
+    def get_val_examples(self):
+        return self._create_examples(path=self.val_path, set_type="val")
+
+    def get_test_examples(self):
+        return self._create_examples(path=self.test_path, set_type="test")
+
+    @classmethod
+    def _create_examples(cls, path, set_type):
+        for i, row in enumerate(py_io.read_jsonl(path)):
+            yield Example(
+                guid="%s-%s" % (set_type, i),
+                text=row["text"],
+                masked_spans=[ExclusiveSpan(start, end) for start, end in row["masked_spans"]],
+            )

--- a/jiant/tasks/lib/mlm_pretokenized.py
+++ b/jiant/tasks/lib/mlm_pretokenized.py
@@ -1,23 +1,14 @@
-import numpy as np
 from dataclasses import dataclass
 from typing import List
 
 import jiant.utils.python.io as py_io
-from jiant.tasks.lib.templates import mlm as mlm_template
 from jiant.tasks.core import (
     Task,
     TaskTypes,
     BaseExample,
-    BaseTokenizedExample,
-    BaseDataRow,
-    BatchMixin,
 )
-from jiant.tasks.utils import ExclusiveSpan, truncate_sequences
-from jiant.tasks.lib.templates.shared import (
-    construct_single_input_tokens_and_segment_ids,
-    create_input_set_from_tokens_and_segments,
-    pad_single_with_feat_spec,
-)
+from jiant.tasks.utils import ExclusiveSpan
+import jiant.tasks.lib.templates.mlm_premasked as mlm_premasked_template
 
 
 @dataclass
@@ -57,68 +48,18 @@ class Example(BaseExample):
 
 
 @dataclass
-class TokenizedExample(BaseTokenizedExample):
-    guid: str
-    masked_tokens: List
-    label_tokens: List
-
-    def featurize(self, tokenizer, feat_spec):
-        # Handle masked_tokens
-        unpadded_masked_inputs = construct_single_input_tokens_and_segment_ids(
-            input_tokens=self.masked_tokens, tokenizer=tokenizer, feat_spec=feat_spec,
-        )
-        masked_input_set = create_input_set_from_tokens_and_segments(
-            unpadded_tokens=unpadded_masked_inputs.unpadded_tokens,
-            unpadded_segment_ids=unpadded_masked_inputs.unpadded_segment_ids,
-            tokenizer=tokenizer,
-            feat_spec=feat_spec,
-        )
-        # Handle label_tokens
-        special_tokens_count = 2  # CLS, SEP
-        pad_token = tokenizer.pad_token
-        unpadded_label_tokens, = truncate_sequences(
-            tokens_ls=[self.label_tokens],
-            max_length=feat_spec.max_seq_length - special_tokens_count,
-        )
-        if feat_spec.cls_token_at_end:
-            unpadded_label_tokens = unpadded_label_tokens + [pad_token, pad_token]
-        else:
-            unpadded_label_tokens = [pad_token] + unpadded_label_tokens + [pad_token]
-        unpadded_label_token_ids = tokenizer.convert_tokens_to_ids(unpadded_label_tokens)
-        masked_lm_labels = pad_single_with_feat_spec(
-            ls=unpadded_label_token_ids, feat_spec=feat_spec, pad_idx=feat_spec.pad_token_id,
-        )
-        masked_lm_labels = np.array(masked_lm_labels)
-        masked_lm_labels[masked_lm_labels == feat_spec.pad_token_id] = \
-            mlm_template.NON_MASKED_TOKEN_LABEL_ID
-        return DataRow(
-            guid=self.guid,
-            masked_input_ids=np.array(masked_input_set.input_ids),
-            input_mask=np.array(masked_input_set.input_mask),
-            segment_ids=np.array(masked_input_set.segment_ids),
-            masked_lm_labels=masked_lm_labels,
-            masked_tokens=unpadded_masked_inputs.unpadded_tokens,
-            label_tokens=unpadded_label_tokens,
-        )
+class TokenizedExample(mlm_premasked_template.TokenizedExample):
+    pass
 
 
 @dataclass
-class DataRow(BaseDataRow):
-    guid: str
-    masked_input_ids: np.ndarray
-    input_mask: np.ndarray
-    segment_ids: np.ndarray
-    masked_lm_labels: np.ndarray
-    masked_tokens: List
-    label_tokens: List
+class DataRow(mlm_premasked_template.BaseDataRow):
+    pass
 
 
 @dataclass
-class Batch(BatchMixin, mlm_template.BaseMLMBatch):
-    def get_masked(self, mlm_probability, tokenizer, do_mask):
-        assert mlm_probability is None
-        assert not do_mask
-        return self
+class Batch(mlm_premasked_template.Batch):
+    pass
 
 
 class MLMPretokenizedTask(Task):
@@ -148,6 +89,6 @@ class MLMPretokenizedTask(Task):
         for i, row in enumerate(py_io.read_jsonl(path)):
             yield Example(
                 guid="%s-%s" % (set_type, i),
-                tokenized_text=row["text"],
+                tokenized_text=row["tokenized_text"],
                 masked_spans=[ExclusiveSpan(start, end) for start, end in row["masked_spans"]],
             )

--- a/jiant/tasks/lib/mlm_pretokenized.py
+++ b/jiant/tasks/lib/mlm_pretokenized.py
@@ -1,0 +1,153 @@
+import numpy as np
+from dataclasses import dataclass
+from typing import List
+
+import jiant.utils.python.io as py_io
+from jiant.tasks.lib.templates import mlm as mlm_template
+from jiant.tasks.core import (
+    Task,
+    TaskTypes,
+    BaseExample,
+    BaseTokenizedExample,
+    BaseDataRow,
+    BatchMixin,
+)
+from jiant.tasks.utils import ExclusiveSpan, truncate_sequences
+from jiant.tasks.lib.templates.shared import (
+    construct_single_input_tokens_and_segment_ids,
+    create_input_set_from_tokens_and_segments,
+    pad_single_with_feat_spec,
+)
+
+
+@dataclass
+class Example(BaseExample):
+    guid: str
+    tokenized_text: List
+    # Spans over token indices
+    masked_spans: List[ExclusiveSpan]
+
+    def tokenize(self, tokenizer):
+        # masked_tokens will be regular tokens except with tokenizer.mask_token for masked spans
+        # label_tokens will be tokenizer.pad_token except with the regular tokens for masked spans
+        masked_tokens = []
+        label_tokens = []
+        curr = 0
+        for start, end in self.masked_spans:
+            # Handle text before next mask
+            tokenized_text = self.tokenized_text[curr:start]
+            masked_tokens += tokenized_text
+            label_tokens += [tokenizer.pad_token] * len(tokenized_text)
+
+            # Handle mask
+            tokenized_masked_text = self.tokenized_text[start:end]
+            masked_tokens += [tokenizer.mask_token] * len(tokenized_masked_text)
+            label_tokens += tokenized_masked_text
+            curr = end
+        if curr < len(self.tokenized_text):
+            tokenized_text = self.tokenized_text[curr:]
+            masked_tokens += tokenized_text
+            label_tokens += [tokenizer.pad_token] * len(tokenized_text)
+
+        return TokenizedExample(
+            guid=self.guid,
+            masked_tokens=self.tokenized_text,
+            label_tokens=label_tokens,
+        )
+
+
+@dataclass
+class TokenizedExample(BaseTokenizedExample):
+    guid: str
+    masked_tokens: List
+    label_tokens: List
+
+    def featurize(self, tokenizer, feat_spec):
+        # Handle masked_tokens
+        unpadded_masked_inputs = construct_single_input_tokens_and_segment_ids(
+            input_tokens=self.masked_tokens, tokenizer=tokenizer, feat_spec=feat_spec,
+        )
+        masked_input_set = create_input_set_from_tokens_and_segments(
+            unpadded_tokens=unpadded_masked_inputs.unpadded_tokens,
+            unpadded_segment_ids=unpadded_masked_inputs.unpadded_segment_ids,
+            tokenizer=tokenizer,
+            feat_spec=feat_spec,
+        )
+        # Handle label_tokens
+        special_tokens_count = 2  # CLS, SEP
+        pad_token = tokenizer.pad_token
+        unpadded_label_tokens, = truncate_sequences(
+            tokens_ls=[self.label_tokens],
+            max_length=feat_spec.max_seq_length - special_tokens_count,
+        )
+        if feat_spec.cls_token_at_end:
+            unpadded_label_tokens = unpadded_label_tokens + [pad_token, pad_token]
+        else:
+            unpadded_label_tokens = [pad_token] + unpadded_label_tokens + [pad_token]
+        unpadded_label_token_ids = tokenizer.convert_tokens_to_ids(unpadded_label_tokens)
+        masked_lm_labels = pad_single_with_feat_spec(
+            ls=unpadded_label_token_ids, feat_spec=feat_spec, pad_idx=feat_spec.pad_token_id,
+        )
+        masked_lm_labels = np.array(masked_lm_labels)
+        masked_lm_labels[masked_lm_labels == feat_spec.pad_token_id] = \
+            mlm_template.NON_MASKED_TOKEN_LABEL_ID
+        return DataRow(
+            guid=self.guid,
+            masked_input_ids=np.array(masked_input_set.input_ids),
+            input_mask=np.array(masked_input_set.input_mask),
+            segment_ids=np.array(masked_input_set.segment_ids),
+            masked_lm_labels=masked_lm_labels,
+            masked_tokens=unpadded_masked_inputs.unpadded_tokens,
+            label_tokens=unpadded_label_tokens,
+        )
+
+
+@dataclass
+class DataRow(BaseDataRow):
+    guid: str
+    masked_input_ids: np.ndarray
+    input_mask: np.ndarray
+    segment_ids: np.ndarray
+    masked_lm_labels: np.ndarray
+    masked_tokens: List
+    label_tokens: List
+
+
+@dataclass
+class Batch(BatchMixin, mlm_template.BaseMLMBatch):
+    def get_masked(self, mlm_probability, tokenizer, do_mask):
+        assert mlm_probability is None
+        assert not do_mask
+        return self
+
+
+class MLMPretokenizedTask(Task):
+    Example = Example
+    TokenizedExample = Example
+    DataRow = DataRow
+    Batch = Batch
+
+    TASK_TYPE = TaskTypes.MASKED_LANGUAGE_MODELING
+
+    def __init__(self, name, path_dict):
+        super().__init__(name=name, path_dict=path_dict)
+        self.mlm_probability = None
+        self.do_mask = True
+
+    def get_train_examples(self):
+        return self._create_examples(path=self.train_path, set_type="train")
+
+    def get_val_examples(self):
+        return self._create_examples(path=self.val_path, set_type="val")
+
+    def get_test_examples(self):
+        return self._create_examples(path=self.test_path, set_type="test")
+
+    @classmethod
+    def _create_examples(cls, path, set_type):
+        for i, row in enumerate(py_io.read_jsonl(path)):
+            yield Example(
+                guid="%s-%s" % (set_type, i),
+                tokenized_text=row["text"],
+                masked_spans=[ExclusiveSpan(start, end) for start, end in row["masked_spans"]],
+            )

--- a/jiant/tasks/lib/mlm_pretokenized.py
+++ b/jiant/tasks/lib/mlm_pretokenized.py
@@ -41,9 +41,7 @@ class Example(BaseExample):
             label_tokens += [tokenizer.pad_token] * len(tokenized_text)
 
         return TokenizedExample(
-            guid=self.guid,
-            masked_tokens=self.tokenized_text,
-            label_tokens=label_tokens,
+            guid=self.guid, masked_tokens=self.tokenized_text, label_tokens=label_tokens,
         )
 
 

--- a/jiant/tasks/lib/mlm_pretokenized.py
+++ b/jiant/tasks/lib/mlm_pretokenized.py
@@ -62,7 +62,7 @@ class Batch(mlm_premasked_template.Batch):
 
 class MLMPretokenizedTask(Task):
     Example = Example
-    TokenizedExample = Example
+    TokenizedExample = TokenizedExample
     DataRow = DataRow
     Batch = Batch
 

--- a/jiant/tasks/lib/templates/mlm.py
+++ b/jiant/tasks/lib/templates/mlm.py
@@ -64,7 +64,6 @@ class DataRow(BaseDataRow):
     tokens: list
 
 
-
 class BaseMLMBatch:
     def get_masked(self, mlm_probability, tokenizer, do_mask):
         raise NotImplementedError

--- a/jiant/tasks/lib/templates/mlm.py
+++ b/jiant/tasks/lib/templates/mlm.py
@@ -18,6 +18,8 @@ from jiant.tasks.lib.templates.shared import (
     create_input_set_from_tokens_and_segments,
 )
 
+NON_MASKED_TOKEN_LABEL_ID = -100
+
 
 @dataclass
 class Example(BaseExample):
@@ -62,8 +64,14 @@ class DataRow(BaseDataRow):
     tokens: list
 
 
+
+class BaseMLMBatch:
+    def get_masked(self, mlm_probability, tokenizer, do_mask):
+        raise NotImplementedError
+
+
 @dataclass
-class Batch(BatchMixin):
+class Batch(BatchMixin, BaseMLMBatch):
     input_ids: torch.LongTensor
     input_mask: torch.LongTensor
     segment_ids: torch.LongTensor
@@ -161,7 +169,7 @@ def mlm_mask_tokens(
         padding_mask = labels.eq(tokenizer.pad_token_id)
         probability_matrix.masked_fill_(padding_mask, value=0.0)
     masked_indices = torch.bernoulli(probability_matrix).bool()
-    labels[~masked_indices] = -100  # We only compute loss on masked tokens
+    labels[~masked_indices] = NON_MASKED_TOKEN_LABEL_ID  # We only compute loss on masked tokens
 
     # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
     indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).bool() & masked_indices

--- a/jiant/tasks/lib/templates/mlm_premasked.py
+++ b/jiant/tasks/lib/templates/mlm_premasked.py
@@ -1,0 +1,129 @@
+import numpy as np
+import torch
+from dataclasses import dataclass
+from typing import List
+
+import jiant.utils.python.io as py_io
+from jiant.tasks.lib.templates import mlm as mlm_template
+from jiant.tasks.core import (
+    Task,
+    TaskTypes,
+    BaseExample,
+    BaseTokenizedExample,
+    BaseDataRow,
+    BatchMixin,
+)
+from jiant.tasks.utils import ExclusiveSpan, truncate_sequences
+from jiant.tasks.lib.templates.shared import (
+    construct_single_input_tokens_and_segment_ids,
+    create_input_set_from_tokens_and_segments,
+    pad_single_with_feat_spec,
+)
+
+
+@dataclass
+class Example(BaseExample):
+    guid: str
+    text: str
+    # Spans over char indices
+    masked_spans: List[ExclusiveSpan]
+
+    def tokenize(self, tokenizer):
+        # masked_tokens will be regular tokens except with tokenizer.mask_token for masked spans
+        # label_tokens will be tokenizer.pad_token except with the regular tokens for masked spans
+        masked_tokens = []
+        label_tokens = []
+        curr = 0
+        for start, end in self.masked_spans:
+            # Handle text before next mask
+            tokenized_text = tokenizer.tokenize(self.text[curr:start])
+            masked_tokens += tokenized_text
+            label_tokens += [tokenizer.pad_token] * len(tokenized_text)
+
+            # Handle mask
+            tokenized_masked_text = tokenizer.tokenize(self.text[start:end])
+            masked_tokens += [tokenizer.mask_token] * len(tokenized_masked_text)
+            label_tokens += tokenized_masked_text
+            curr = end
+        if curr < len(self.text):
+            tokenized_text = tokenizer.tokenize(self.text[curr:])
+            masked_tokens += tokenized_text
+            label_tokens += [tokenizer.pad_token] * len(tokenized_text)
+
+        return TokenizedExample(
+            guid=self.guid,
+            masked_tokens=masked_tokens,
+            label_tokens=label_tokens,
+        )
+
+
+@dataclass
+class TokenizedExample(BaseTokenizedExample):
+    guid: str
+    masked_tokens: List
+    label_tokens: List
+
+    def featurize(self, tokenizer, feat_spec):
+        # Handle masked_tokens
+        unpadded_masked_inputs = construct_single_input_tokens_and_segment_ids(
+            input_tokens=self.masked_tokens, tokenizer=tokenizer, feat_spec=feat_spec,
+        )
+        masked_input_set = create_input_set_from_tokens_and_segments(
+            unpadded_tokens=unpadded_masked_inputs.unpadded_tokens,
+            unpadded_segment_ids=unpadded_masked_inputs.unpadded_segment_ids,
+            tokenizer=tokenizer,
+            feat_spec=feat_spec,
+        )
+        # Handle label_tokens
+        special_tokens_count = 2  # CLS, SEP
+        pad_token = tokenizer.pad_token
+        unpadded_label_tokens, = truncate_sequences(
+            tokens_ls=[self.label_tokens],
+            max_length=feat_spec.max_seq_length - special_tokens_count,
+        )
+        if feat_spec.cls_token_at_end:
+            unpadded_label_tokens = unpadded_label_tokens + [pad_token, pad_token]
+        else:
+            unpadded_label_tokens = [pad_token] + unpadded_label_tokens + [pad_token]
+        unpadded_label_token_ids = tokenizer.convert_tokens_to_ids(unpadded_label_tokens)
+        masked_lm_labels = pad_single_with_feat_spec(
+            ls=unpadded_label_token_ids, feat_spec=feat_spec, pad_idx=feat_spec.pad_token_id,
+        )
+        masked_lm_labels = np.array(masked_lm_labels)
+        masked_lm_labels[masked_lm_labels == feat_spec.pad_token_id] = \
+            mlm_template.NON_MASKED_TOKEN_LABEL_ID
+        return DataRow(
+            guid=self.guid,
+            masked_input_ids=np.array(masked_input_set.input_ids),
+            input_mask=np.array(masked_input_set.input_mask),
+            segment_ids=np.array(masked_input_set.segment_ids),
+            masked_lm_labels=masked_lm_labels,
+            masked_tokens=unpadded_masked_inputs.unpadded_tokens,
+            label_tokens=unpadded_label_tokens,
+        )
+
+
+@dataclass
+class DataRow(BaseDataRow):
+    guid: str
+    masked_input_ids: np.ndarray
+    input_mask: np.ndarray
+    segment_ids: np.ndarray
+    masked_lm_labels: np.ndarray
+    masked_tokens: List
+    label_tokens: List
+
+
+@dataclass
+class Batch(BatchMixin, mlm_template.BaseMLMBatch):
+    masked_input_ids: torch.LongTensor
+    input_mask: torch.LongTensor
+    segment_ids: torch.LongTensor
+    masked_lm_labels: torch.LongTensor
+    masked_tokens: List
+    label_tokens: List
+
+    def get_masked(self, mlm_probability, tokenizer, do_mask):
+        assert mlm_probability is None
+        assert not do_mask
+        return self

--- a/jiant/tasks/lib/templates/mlm_premasked.py
+++ b/jiant/tasks/lib/templates/mlm_premasked.py
@@ -3,11 +3,8 @@ import torch
 from dataclasses import dataclass
 from typing import List
 
-import jiant.utils.python.io as py_io
 from jiant.tasks.lib.templates import mlm as mlm_template
 from jiant.tasks.core import (
-    Task,
-    TaskTypes,
     BaseExample,
     BaseTokenizedExample,
     BaseDataRow,
@@ -51,9 +48,7 @@ class Example(BaseExample):
             label_tokens += [tokenizer.pad_token] * len(tokenized_text)
 
         return TokenizedExample(
-            guid=self.guid,
-            masked_tokens=masked_tokens,
-            label_tokens=label_tokens,
+            guid=self.guid, masked_tokens=masked_tokens, label_tokens=label_tokens,
         )
 
 
@@ -77,7 +72,7 @@ class TokenizedExample(BaseTokenizedExample):
         # Handle label_tokens
         special_tokens_count = 2  # CLS, SEP
         pad_token = tokenizer.pad_token
-        unpadded_label_tokens, = truncate_sequences(
+        (unpadded_label_tokens,) = truncate_sequences(
             tokens_ls=[self.label_tokens],
             max_length=feat_spec.max_seq_length - special_tokens_count,
         )
@@ -90,8 +85,9 @@ class TokenizedExample(BaseTokenizedExample):
             ls=unpadded_label_token_ids, feat_spec=feat_spec, pad_idx=feat_spec.pad_token_id,
         )
         masked_lm_labels = np.array(masked_lm_labels)
-        masked_lm_labels[masked_lm_labels == feat_spec.pad_token_id] = \
-            mlm_template.NON_MASKED_TOKEN_LABEL_ID
+        masked_lm_labels[
+            masked_lm_labels == feat_spec.pad_token_id
+        ] = mlm_template.NON_MASKED_TOKEN_LABEL_ID
         return DataRow(
             guid=self.guid,
             masked_input_ids=np.array(masked_input_set.input_ids),

--- a/jiant/tasks/retrieval.py
+++ b/jiant/tasks/retrieval.py
@@ -19,6 +19,8 @@ from jiant.tasks.lib.edge_probing.dpr import DprTask
 from jiant.tasks.lib.glue_diagnostics import GlueDiagnosticsTask
 from jiant.tasks.lib.hellaswag import HellaSwagTask
 from jiant.tasks.lib.mlm_simple import MLMSimpleTask
+from jiant.tasks.lib.mlm_premasked import MLMPremaskedTask
+from jiant.tasks.lib.mlm_pretokenized import MLMPretokenizedTask
 from jiant.tasks.lib.mlqa import MlqaTask
 from jiant.tasks.lib.mnli import MnliTask
 from jiant.tasks.lib.mnli_mismatched import MnliMismatchedTask
@@ -81,6 +83,8 @@ TASK_DICT = {
     "glue_diagnostics": GlueDiagnosticsTask,
     "hellaswag": HellaSwagTask,
     "mlm_simple": MLMSimpleTask,
+    "mlm_premasked": MLMPremaskedTask,
+    "mlm_pretokenized": MLMPretokenizedTask,
     "mlqa": MlqaTask,
     "mnli": MnliTask,
     "mnli_mismatched": MnliMismatchedTask,

--- a/tests/tasks/lib/test_mlm_premasked.py
+++ b/tests/tasks/lib/test_mlm_premasked.py
@@ -1,9 +1,10 @@
 import transformers
 
+import jiant.shared.model_resolution as model_resolution
 import jiant.tasks as tasks
 
 
-def test_tokenization():
+def test_tokenization_and_featurization():
     task = tasks.MLMPremaskedTask(name="mlm_premasked", path_dict={})
     tokenizer = transformers.RobertaTokenizer.from_pretrained("roberta-base")
     example = task.Example(
@@ -16,3 +17,15 @@ def test_tokenization():
         ['Hi', ',', 'Ġmy', 'Ġname', 'Ġis', 'Ġ', '<mask>', 'ĠRoberts', '.']
     assert tokenized_example.label_tokens == \
         ['<pad>', '<pad>', '<pad>', '<pad>', '<pad>', '<pad>', 'Bob', '<pad>', '<pad>']
+
+    data_row = tokenized_example.featurize(
+        tokenizer=tokenizer,
+        feat_spec=model_resolution.build_featurization_spec(
+            model_type="roberta-base",
+            max_seq_length=16,
+        )
+    )
+    assert list(data_row.masked_input_ids) == \
+        [0, 30086, 6, 127, 766, 16, 1437, 50264, 6274, 4, 2, 1, 1, 1, 1, 1]
+    assert list(data_row.masked_lm_labels) == \
+        [-100, -100, -100, -100, -100, -100, -100, 25158, -100, -100, -100, -100, -100, -100, -100, -100]

--- a/tests/tasks/lib/test_mlm_premasked.py
+++ b/tests/tasks/lib/test_mlm_premasked.py
@@ -1,0 +1,18 @@
+import transformers
+
+import jiant.tasks as tasks
+
+
+def test_tokenization():
+    task = tasks.MLMPremaskedTask(name="mlm_premasked", path_dict={})
+    tokenizer = transformers.RobertaTokenizer.from_pretrained("roberta-base")
+    example = task.Example(
+        guid=None,
+        text="Hi, my name is Bob Roberts.",
+        masked_spans=[[15, 18]],
+    )
+    tokenized_example = example.tokenize(tokenizer=tokenizer)
+    assert tokenized_example.masked_tokens == \
+        ['Hi', ',', 'Ġmy', 'Ġname', 'Ġis', 'Ġ', '<mask>', 'ĠRoberts', '.']
+    assert tokenized_example.label_tokens == \
+        ['<pad>', '<pad>', '<pad>', '<pad>', '<pad>', '<pad>', 'Bob', '<pad>', '<pad>']

--- a/tests/tasks/lib/test_mlm_pretokenized.py
+++ b/tests/tasks/lib/test_mlm_pretokenized.py
@@ -1,9 +1,10 @@
 import transformers
 
+import jiant.shared.model_resolution as model_resolution
 import jiant.tasks as tasks
 
 
-def test_tokenization():
+def test_tokenization_and_featurization():
     task = tasks.MLMPretokenizedTask(name="mlm_pretokenized", path_dict={})
     tokenizer = transformers.RobertaTokenizer.from_pretrained("roberta-base")
     example = task.Example(
@@ -16,3 +17,15 @@ def test_tokenization():
         ['Hi', ',', 'Ġmy', 'Ġname', 'Ġis', 'ĠBob', 'ĠRoberts', '.']
     assert tokenized_example.label_tokens == \
         ['<pad>', '<pad>', 'Ġmy', '<pad>', '<pad>', 'ĠBob', '<pad>', '<pad>']
+
+    data_row = tokenized_example.featurize(
+        tokenizer=tokenizer,
+        feat_spec=model_resolution.build_featurization_spec(
+            model_type="roberta-base",
+            max_seq_length=16,
+        )
+    )
+    assert list(data_row.masked_input_ids) == \
+        [0, 30086, 6, 127, 766, 16, 3045, 6274, 4, 2, 1, 1, 1, 1, 1, 1]
+    assert list(data_row.masked_lm_labels) == \
+        [-100, -100, -100, 127, -100, -100, 3045, -100, -100, -100, -100, -100, -100, -100, -100, -100]

--- a/tests/tasks/lib/test_mlm_pretokenized.py
+++ b/tests/tasks/lib/test_mlm_pretokenized.py
@@ -1,0 +1,18 @@
+import transformers
+
+import jiant.tasks as tasks
+
+
+def test_tokenization():
+    task = tasks.MLMPretokenizedTask(name="mlm_pretokenized", path_dict={})
+    tokenizer = transformers.RobertaTokenizer.from_pretrained("roberta-base")
+    example = task.Example(
+        guid=None,
+        tokenized_text=['Hi', ',', 'Ġmy', 'Ġname', 'Ġis', 'ĠBob', 'ĠRoberts', '.'],
+        masked_spans=[[2, 3], [5, 6]],
+    )
+    tokenized_example = example.tokenize(tokenizer=tokenizer)
+    assert tokenized_example.masked_tokens == \
+        ['Hi', ',', 'Ġmy', 'Ġname', 'Ġis', 'ĠBob', 'ĠRoberts', '.']
+    assert tokenized_example.label_tokens == \
+        ['<pad>', '<pad>', 'Ġmy', '<pad>', '<pad>', 'ĠBob', '<pad>', '<pad>']


### PR DESCRIPTION
Adding two generic tasks, both supporting cases where we're doing MLM over pre-specified masked inputs.

* `mlm_premasked`: Input is text, masks specified as char spans. The tokenization is not 100% correct (we're basically tokenizing each segment separately, which is not the same as tokenizing the whole sequence), but assuming this will be used in fine-tuning, this should be fine.
* `mlm_pretokenized`: Input is list of tokens (has to be specific to tokenizer) masks are specific as token spans. This provides an option for when tokenization needs to be 100% correct.